### PR TITLE
Add custom color palette to Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,58 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
-const colors = require('tailwindcss/colors');
+
+// Your 10-color palette (light to dark)
+const colorPalette = {
+  // Light backgrounds (lightest 3 colors)
+  'palette-1': '#F5EBC9',  // Light cream yellow
+  'palette-2': '#E8D5C4',  // Warm beige
+  'palette-3': '#DFC0C9',  // Soft taupe
+  
+  // Mid tones (colors 4-6)
+  'palette-4': '#D4A8D4',  // Light mauve
+  'palette-5': '#C294DC',  // Soft purple
+  'palette-6': '#9B7FBF',  // Medium purple
+  
+  // Dark tones (darkest 4 colors)
+  'palette-7': '#6B5BA3',  // Deep purple
+  'palette-8': '#4A4680',  // Dark indigo
+  'palette-9': '#2F2E5E',  // Very dark navy
+  'palette-10': '#1a1a3e', // Darkest navy
+};
 
 module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      colors: {
+        // Custom palette colors
+        palette: colorPalette,
+        
+        // Semantic color mappings for easy usage
+        primary: {
+          light: colorPalette['palette-4'],   // Mauve
+          DEFAULT: colorPalette['palette-5'], // Soft purple
+          dark: colorPalette['palette-7'],    // Deep purple
+        },
+        secondary: {
+          light: colorPalette['palette-2'],   // Beige
+          DEFAULT: colorPalette['palette-6'], // Medium purple
+          dark: colorPalette['palette-8'],    // Dark indigo
+        },
+        accent: {
+          light: colorPalette['palette-1'],   // Cream yellow (for highlights)
+          DEFAULT: colorPalette['palette-3'], // Soft taupe
+          dark: colorPalette['palette-9'],    // Very dark navy
+        },
+        background: {
+          light: colorPalette['palette-10'],  // Darkest navy (main background)
+          DEFAULT: colorPalette['palette-10'],
+          paper: colorPalette['palette-9'],   // Very dark navy (cards)
+        },
+        surface: {
+          light: colorPalette['palette-9'],   // Dark navy
+          DEFAULT: colorPalette['palette-8'], // Dark indigo
+        },
+      },
       fontFamily: {
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
         brand: ['Inter', 'sans-serif'],
@@ -13,74 +61,75 @@ module.exports = {
       boxShadow: {
         xs: '0 0 0 1px rgba(0, 0, 0, 0.05)',
         solid: '0 0 0 2px currentColor',
-        outline: `0 0 0 3px rgba(156, 163, 175, .5)`,
-        'outline-gray': `0 0 0 3px rgba(254, 202, 202, .5)`,
-        'outline-blue': `0 0 0 3px rgba(191, 219, 254, .5)`,
-        'outline-green': `0 0 0 3px rgba(167, 243, 208, .5)`,
-        'outline-yellow': `0 0 0 3px rgba(253, 230, 138, .5)`,
-        'outline-red': `0 0 0 3px rgba(254, 202, 202, .5)`,
-        'outline-pink': `0 0 0 3px rgba(251, 207, 232, .5)`,
-        'outline-purple': `0 0 0 3px rgba(221, 214, 254, .5)`,
-        'outline-indigo': `0 0 0 3px rgba(199, 210, 254, .5)`,
+        outline: `0 0 0 3px rgba(212, 168, 212, .5)`,
+        'outline-primary': `0 0 0 3px rgba(194, 148, 220, .5)`,
+        'outline-accent': `0 0 0 3px rgba(245, 235, 201, .5)`,
       },
       typography: theme => ({
         light: {
           css: [
             {
-              color: theme('colors.gray.400'),
+              color: theme('colors.palette.2'),
               '[class~="lead"]': {
-                color: theme('colors.gray.300'),
+                color: theme('colors.palette.1'),
               },
               a: {
-                color: theme('colors.white'),
+                color: theme('colors.palette.1'),
+                textDecoration: 'underline',
+                '&:hover': {
+                  color: theme('colors.palette.4'),
+                },
               },
               strong: {
-                color: theme('colors.white'),
+                color: theme('colors.palette.1'),
               },
               'ol > li::before': {
-                color: theme('colors.gray.400'),
+                color: theme('colors.palette.2'),
               },
               'ul > li::before': {
-                backgroundColor: theme('colors.gray.600'),
+                backgroundColor: theme('colors.palette.6'),
               },
               hr: {
-                borderColor: theme('colors.gray.200'),
+                borderColor: theme('colors.palette.8'),
               },
               blockquote: {
-                color: theme('colors.gray.200'),
-                borderLeftColor: theme('colors.gray.600'),
+                color: theme('colors.palette.2'),
+                borderLeftColor: theme('colors.palette.6'),
               },
               h1: {
-                color: theme('colors.white'),
+                color: theme('colors.palette.1'),
               },
               h2: {
-                color: theme('colors.white'),
+                color: theme('colors.palette.2'),
               },
               h3: {
-                color: theme('colors.white'),
+                color: theme('colors.palette.3'),
               },
               h4: {
-                color: theme('colors.white'),
+                color: theme('colors.palette.4'),
               },
               'figure figcaption': {
-                color: theme('colors.gray.400'),
+                color: theme('colors.palette.3'),
               },
               code: {
-                color: theme('colors.white'),
+                color: theme('colors.palette.1'),
+                backgroundColor: theme('colors.palette.8'),
+                padding: '0.2em 0.4em',
+                borderRadius: '0.3em',
               },
               'a code': {
-                color: theme('colors.white'),
+                color: theme('colors.palette.1'),
               },
               pre: {
-                color: theme('colors.gray.200'),
-                backgroundColor: theme('colors.gray.800'),
+                color: theme('colors.palette.2'),
+                backgroundColor: theme('colors.palette.9'),
               },
               thead: {
-                color: theme('colors.white'),
-                borderBottomColor: theme('colors.gray.400'),
+                color: theme('colors.palette.1'),
+                borderBottomColor: theme('colors.palette.6'),
               },
               'tbody tr': {
-                borderBottomColor: theme('colors.gray.600'),
+                borderBottomColor: theme('colors.palette.8'),
               },
             },
           ],
@@ -109,7 +158,6 @@ module.exports = {
       },
     },
   },
-  darkMode: 'class',
   plugins: [
     require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),


### PR DESCRIPTION
Added a custom 10-color palette for theming and updated color references throughout the configuration.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x ] I have tested my code.
- [ x] I have followed the content guidelines in docs/Math_Topic_Template.md.
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ x] I have linked this PR to any issues that it closes.
