### PR TITLE
Rename multi-part module titles to roman numerals and remove divider …

### DIFF
--- a/content/1_Foundations/Absolute_Value_Integers_p1.mdx
+++ b/content/1_Foundations/Absolute_Value_Integers_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: absolute-value-integers_p1
-title: Integer Operations and Notations (Part 1)
+title: Integer Operations and Notations I
 author: Pranav Ramesh
 description: Navigating negative numbers and distance on a number line without sign errors.
 prerequisites: []

--- a/content/1_Foundations/Absolute_Value_Integers_p2.mdx
+++ b/content/1_Foundations/Absolute_Value_Integers_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: absolute-value-integers_p2
-title: Integer Operations and Notations (Part 2)
+title: Integer Operations and Notations II
 author: Pranav Ramesh
 description: Navigating negative numbers and distance on a number line without sign errors.
 prerequisites: []

--- a/content/1_Foundations/Chart_Graph_Interpretation.mdx
+++ b/content/1_Foundations/Chart_Graph_Interpretation.mdx
@@ -1,6 +1,6 @@
 ---
 id: chart-graph-interpretation-p1
-title: Chart and Graph Interpretation (Part 1)
+title: Chart and Graph Interpretation I
 author: Pranav Ramesh
 description: Extracting data from histograms, pie charts, and complex bar graphs.
 prerequisites: []
@@ -11,8 +11,6 @@ prerequisites: []
 Graphs and charts are used to give a visual representation of data. They condense large amounts of information into easy-to-understand formats that clearly and effectively communicate important points.
  
 Reading a graph or chart means that we can look at the chart or graph and understand what it is trying to tell us. It involves picking out data points of interest and gives a quick synopsis of what the graph is about. Interpreting a graph or chart involves digging a little deeper. This may include completing calculations to determine an average or a sum or difference of data values.
- 
----
  
 ## Explore 1 – Interpreting a Bar Graph
  
@@ -45,8 +43,6 @@ The horizontal bar graph shows the percentage of people aged 65 or older in each
  
 > **Solution:** A bar graph is appropriate since the data is qualitative: nominal and the categories can be rearranged in any order.
  
----
- 
 ## Explore 2 – Interpreting a Bar Graph
  
 The bar graph shows the graduation rates by race/ethnicity within 6 years from first institution attended for first-time, full-time bachelor's degree-seeking students at 4-year postsecondary institutions, where the cohort entry year is 2010.
@@ -67,8 +63,6 @@ The bar graph shows the graduation rates by race/ethnicity within 6 years from f
 > **Solution:** Disagree. The number of people in each ethnic group is different. Even though the group Asians has the highest graduation rate of 74%, this does not mean that the number of Asians is larger than the number of people in any other ethnic group. We are not told how many graduates are in each ethnic group.
  
 Sometimes two line graphs are combined onto a single graph to highlight what is happening with the data or to tell a story. They may or may not use the same vertical scale. It is important to recognize the scale for each line graph. This is often done using color coding.
- 
----
  
 ## Explore 3 – Reading and Interpreting a Line Graph
  
@@ -96,8 +90,6 @@ The line graph shows the number of visitors (the green line) and the number of f
 **5. The upper (green) and lower (orange) lines get further apart as the graphs move from 2010 to 2022. What does this tell us?**
  
 > **Solution:** As the upper (green) line increases the lower (orange) line decreases, telling us that although the number of visitors increased, the number of full-time equivalent employees decreased.
- 
----
  
 ## Explore 4 – Interpreting Line Graphs
  
@@ -132,7 +124,5 @@ The two graphs show the growth (Chart 2) and loss (Chart 3) of non-government-co
 **6. What was the highest job loss rate for the U.S. and for Utah? How does it relate to the recession period?**
  
 > **Solution:** The peak on Chart 3 shows the highest value around 17% for the U.S. and 11% for Utah. This was right after the defined recession period ended.
- 
----
  
  ## Part 2: Check the Part 2 for the continuation!!

--- a/content/1_Foundations/Chart_Graph_Interpretation_part2.mdx
+++ b/content/1_Foundations/Chart_Graph_Interpretation_part2.mdx
@@ -1,6 +1,6 @@
 ---
 id: chart-graph-interpretation-p2
-title: Chart and Graph Interpretation (Part 2)
+title: Chart and Graph Interpretation II
 author: Pranav Ramesh
 description: Extracting data from histograms, pie charts, and complex bar graphs.
 prerequisites: []
@@ -41,8 +41,6 @@ The pie chart shows the percentage distribution of the Food and Drug Administrat
  
 > **Solution:** 33% = 0.33, while 1/3 = 0.33333…, so since these are very close and the percentages on the pie chart are rounded, the student is correct.
  
----
- 
 ## Explore 6 – Interpreting Pie Charts
  
 The two pie charts show the water use percentages of different categories in Utah. The first pie chart shows all categories of water use in Utah. The second pie chart shows all categories of non-irrigation water use.
@@ -65,8 +63,6 @@ The two pie charts show the water use percentages of different categories in Uta
 **4. If Utah were to cut its water use, which sector should be mandated to cut its water use? Explain your reasoning.**
  
 > **Solution:** 81% of all water goes towards irrigation. That is the first sector that should be cut. 51% of the non-irrigation water is used by residential customers. That could also be cut to save water.
- 
----
  
 ## Explore 7 – Interpreting a Histogram
  
@@ -99,8 +95,6 @@ The histogram shows the box office revenue for movies in the US from 2012–2021
  
 > **Solution:** Each bar represents the sum of all box office revenues across the US per year so is a calculated amount (continuous) that has been rounded to a tenth of a billion dollars. Year represents time, which is continuous. So a line graph would be an appropriate graph.
  
----
- 
 ### Reflect
  
 > A student claims that each bar in a bar graph is a data point, where the value associated with a bar is the value of the data point. Do you agree? Explain your reasoning.
@@ -110,7 +104,6 @@ The histogram shows the box office revenue for movies in the US from 2012–2021
 The student's claim is NOT correct. Each bar is the summary of a number of data points. The value associated with each bar tells us how many (or what percentage) are in that category. For example, in Explore 1, the data points that make up the bar labeled *Utah County* are the people who live in Utah County who are 65 or older.
  
 </details>
----
  
 ## Practice Example
  
@@ -134,5 +127,4 @@ The student's claim is NOT correct. Each bar is the summary of a number of data 
 6. 6.38 or 638%
 7. 91 per 100,000
 </details>
----
 *This chapter is adapted from [Numeracy](https://uen.pressbooks.pub/uvumqr) by Utah Valley University, licensed under [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/).*

--- a/content/1_Foundations/Estimation_Bounding.mdx
+++ b/content/1_Foundations/Estimation_Bounding.mdx
@@ -62,8 +62,6 @@ $$317 \times 52 \approx 300 \times 50 = 15000.$$
 
 The exact value is $16484$. If the answer choices were $500$, $2000$, $16484$, $50000$, $200000$ — only $16484$ is near our estimate.
 
----
-
 ### Problem 2
 
 Estimate $\dfrac{4987 \times 6}{1003}$ without a calculator.
@@ -73,8 +71,6 @@ Estimate $\dfrac{4987 \times 6}{1003}$ without a calculator.
 $$\frac{4987 \times 6}{1003} \approx \frac{5000 \times 6}{1000} = \frac{30000}{1000} = 30.$$
 
 The exact value is $\approx 29.84$. Our estimate of $30$ immediately eliminates any answer choices far from $30$.
-
----
 
 ### Problem 3
 
@@ -86,8 +82,6 @@ $$198 \times 63 \approx 200 \times 60 = 12000.$$
 
 The exact value is $12474$. The closest answer choice is $12000$.
 
----
-
 ### Problem 4
 
 Estimate $\dfrac{999 \times 999}{1001}$ without a calculator.
@@ -97,8 +91,6 @@ Estimate $\dfrac{999 \times 999}{1001}$ without a calculator.
 $$\frac{999 \times 999}{1001} \approx \frac{1000 \times 1000}{1000} = 1000.$$
 
 The exact value is $\approx 998$. Since $999 \times 999 \approx 1000^2$ and $1001 \approx 1000$, a quick squeeze confirms the answer is just under $1000$.
-
----
 
 ### Problem 5
 
@@ -110,8 +102,6 @@ $$\frac{99 \times 100}{2} \approx \frac{100 \times 100}{2} = 5000.$$
 
 The exact value is $4950$. You can also bound directly: there are $99$ terms each between $1$ and $99$, so a midpoint estimate gives $50 \times 99 = 4950$.
 
----
-
 ### Problem 6
 
 Estimate $\sqrt{620}$ to the nearest integer.
@@ -121,8 +111,6 @@ Estimate $\sqrt{620}$ to the nearest integer.
 $$24 < \sqrt{620} < 25.$$
 
 Since $620$ is very close to $625$, we know $\sqrt{620}$ is very close to $25$. The exact value is $\approx 24.9$.
-
----
 
 ### Problem 7
 
@@ -134,8 +122,6 @@ $$\frac{2998 \times 15}{497} \approx \frac{3000 \times 15}{500} = \frac{45000}{5
 
 The exact value is $\approx 90.54$. Our estimate of $90$ is essentially exact.
 
----
-
 ### Problem 8
 
 A rectangle has side lengths $203$ and $397$. Estimate its area.
@@ -146,8 +132,6 @@ $$203 \times 397 \approx 200 \times 400 = 80000.$$
 
 The exact value is $80591$. If answer choices are $8000$, $40000$, $80591$, $160000$, $400000$ — only $80591$ matches.
 
----
-
 ### Problem 9
 
 Estimate $\dfrac{1}{0.0204}$ without a calculator.
@@ -157,8 +141,6 @@ Estimate $\dfrac{1}{0.0204}$ without a calculator.
 $$\frac{1}{0.0204} \approx \frac{1}{0.02} = 50.$$
 
 The exact value is $\approx 49.02$. Rounding the denominator up slightly means our estimate is slightly high, so the true answer is just under $50$.
-
----
 
 ### Problem 10
 

--- a/content/1_Foundations/Exponent_Rules.mdx
+++ b/content/1_Foundations/Exponent_Rules.mdx
@@ -36,8 +36,6 @@ $$
 
 *Example:* $2^3 \cdot 2^4 = 2^7 = 128$
 
----
-
 **Quotient Rule**
 
 When dividing two powers with the same base, subtract the exponents:
@@ -47,8 +45,6 @@ $$
 $$
 
 *Example:* $\frac{5^6}{5^2} = 5^4 = 625$
-
----
 
 **Power Rule**
 
@@ -60,8 +56,6 @@ $$
 
 *Example:* $(3^2)^4 = 3^8 = 6561$
 
----
-
 **Power of a Product**
 
 An exponent outside parentheses distributes to every factor inside:
@@ -71,8 +65,6 @@ $$
 $$
 
 *Example:* $(2 \cdot 3)^3 = 8 \cdot 27 = 216$
-
----
 
 **Power of a Quotient**
 
@@ -84,8 +76,6 @@ $$
 
 *Example:* $\left(\frac{4}{2}\right)^3 = \frac{64}{8} = 8$
 
----
-
 **Negative Exponent Rule**
 
 A negative exponent means *reciprocal* and not a negative result:
@@ -95,8 +85,6 @@ a^{-n} = \frac{1}{a^n}, \quad a \neq 0
 $$
 
 *Example:* $2^{-3} = \frac{1}{8} = 0.125$
-
----
 
 ### Special Cases
 
@@ -110,8 +98,6 @@ $$
 
 This follows directly from the quotient rule: $\frac{a^n}{a^n} = a^{n-n} = a^0 = 1$. Note that $0^0$ is indeterminate.
 
----
-
 **Exponent of One**
 
 Any base raised to the power of 1 is simply itself:
@@ -119,8 +105,6 @@ Any base raised to the power of 1 is simply itself:
 $$
 a^1 = a
 $$
-
----
 
 **Fractional Exponents**
 
@@ -130,8 +114,6 @@ $a^{1/n} = \sqrt[n]{a}$ and more generally,
 $a^{m/n} = (\sqrt[n]{a})^m$
 
 Example: $8^{1/3} = \sqrt[3]{8} = 2$ and $8^{2/3} = (\sqrt[3]{8})^2 = 4$
-
----
 
 ### Putting It All Together
 
@@ -144,7 +126,6 @@ Importantly, $a^{(b^c)}$ is not the same as $(a^b)^c$. Instead, for the former, 
 ## Worked Example
 
 > Simplify $\frac{(2x^3y^{-2})^2}{4x^{-1}y}$.
----
 
 ### Step 1: Apply the power of a product rule to the numerator
 

--- a/content/1_Foundations/Fractions_Percentages_Proportions_p1.mdx
+++ b/content/1_Foundations/Fractions_Percentages_Proportions_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: fractions_percentages_proportions_p1
-title: Proportional Reasoning (Part 1)
+title: Proportional Reasoning I
 author: Pranav Ramesh
 description: Fractions, Proportions, Types of Variations and Scaling.
 prerequisites: []
@@ -107,8 +107,6 @@ For example, finding half of three-fourths:
 $$
 \frac{1}{2} \times \frac{3}{4} = \frac{3}{8}
 $$
-
----
 
 ### Division of Fractions
 

--- a/content/1_Foundations/Fractions_Percentages_Proportions_p2.mdx
+++ b/content/1_Foundations/Fractions_Percentages_Proportions_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: fractions_percentages_proportions_p2
-title: Proportional Reasoning (Part 2)
+title: Proportional Reasoning II
 author: Pranav Ramesh
 description: Fractions, Proportions, Types of Variations and Scaling.
 prerequisites: []

--- a/content/1_Foundations/Geometric_Sequences.mdx
+++ b/content/1_Foundations/Geometric_Sequences.mdx
@@ -197,8 +197,6 @@ $$
 \frac{k}{2} = (2)(3) + (2)\!\left(\tfrac{9}{2}\right) + (3)\!\left(\tfrac{9}{2}\right) = 6 + 9 + \frac{27}{2} = \frac{57}{2}.
 $$
 Therefore $k = \boxed{57}$.
-
----
  
 > Example 3: The sum of three consecutive terms in a geometric sequence is 39, and the sum of their squares is 741. Find the three terms.
  
@@ -270,8 +268,6 @@ Taking $r = \frac{5}{2}$: the three terms are $4,\ 10,\ 25$.
 $\\$
 The three terms are $\boxed{4, 10, 25}$.
  
----
- 
 > Example 4: Evaluate the sum $4 - \dfrac{8}{3} + \dfrac{16}{9} - \dfrac{32}{27} + \cdots$
  
 Solution: We first identify this as a geometric series. The first term is $a = 4$. To find the common ratio, we divide the second term by the first:
@@ -285,8 +281,6 @@ Since $|r| = \frac{2}{3} < 1$, the series converges. Applying the infinite geome
 $$
 S = \frac{4}{1 - \left(-\dfrac{2}{3}\right)} = \frac{4}{\dfrac{5}{3}} = 4 \cdot \frac{3}{5} = \boxed{\dfrac{12}{5}}.
 $$
- 
----
  
 > Example 5: Write the following expression as a single polynomial:
 > $$\frac{(t^2 + t + 1)(t^{12} + t^9 + t^6 + t^3 + 1)}{t^{10} + t^5 + 1}$$

--- a/content/1_Foundations/Linear_Diophantine_Equations.problems.json
+++ b/content/1_Foundations/Linear_Diophantine_Equations.problems.json
@@ -199,7 +199,7 @@
     {
       "uniqueId": "amc8-2016-11",
       "name": "Problem 11 (2016 AMC 8)",
-      "url": "https://artofproblemsolving.com/wiki/index.php?title=2016_AMC_8_Problems/Problem_11",
+      "url": "https://artofproblemsolving.com/wiki/index.php/2016_AMC_8_Problems/Problem_11",
       "source": "AMC 8",
       "difficulty": "Easy",
       "isStarred": false,
@@ -280,7 +280,7 @@
     {
       "uniqueId": "amc8-2023-18",
       "name": "Problem 18 (2023 AMC 8)",
-      "url": "https://artofproblemsolving.com/wiki/index.php?title=2023_AMC_8_Problems/Problem_18",
+      "url": "https://artofproblemsolving.com/wiki/index.php/2023_AMC_8_Problems/Problem_18",
       "source": "AMC 8",
       "difficulty": "Normal",
       "isStarred": false,
@@ -307,7 +307,7 @@
     {
       "uniqueId": "amc8-2025-23",
       "name": "Problem 23 (2025 AMC 8)",
-      "url": "https://artofproblemsolving.com/wiki/index.php?title=2025_AMC_8_Problems/Problem_16",
+      "url": "https://artofproblemsolving.com/wiki/index.php/2025_AMC_8_Problems/Problem_23",
       "source": "AMC 8",
       "difficulty": "Hard",
       "isStarred": false,

--- a/content/1_Foundations/Linear_Equations_Inequalities.mdx
+++ b/content/1_Foundations/Linear_Equations_Inequalities.mdx
@@ -12,15 +12,12 @@ Linear equations and inequalities are composed of constants and variables.
 
 - Linear equations use the equal sign ($=$). (For example, $2x+1=5$ is a linear equation.)
 - Linear inequalities use inequality signs ($ > $, $ < $, $\geq$, and $\leq$). (For example, $2x+1>5$ is a linear inequality)
----
 
 ## Types of linear equations
 
 The goal of solving a linear equation is to find the value of a variable; we isolate the variable step by step until only the variable is on one side of the equation and only a constant is on the other.
 
 When solving linear equations, the most important thing to remember is that the equation will remain equivalent to the original equation only if we always treat both sides equally: whenever we do something to one side, we must do the exact same thing to the other side.
-
----
 
 ## Linear Equations in One Variable
 
@@ -59,8 +56,6 @@ These examples walk through isolating $x$ in a one-variable linear equation, inc
 > x = \frac{3}{2}
 >$$
 
----
-
 ## Equations with Fractions and Negative Numbers
 
 Fractions and negative numbers can make linear equations trickier to solve. If an equation has only a fraction coefficient, it's often easiest to leave the fraction until the last step. If it has both fraction coefficients and fraction constants, clearing the fractions in the first step usually simplifies things.
@@ -97,8 +92,6 @@ Fractions and negative numbers can make linear equations trickier to solve. If a
 > x = \frac{9}{2}
 >$$
 
----
-
 ## Linear Equations in Two Variables
 
 When an equation has two variables and the value of one of them is given, substitute the known value into the equation and solve for the other.
@@ -114,8 +107,6 @@ When an equation has two variables and the value of one of them is given, substi
 > y = -1
 >$$
 
----
-
 ## Evaluating Expressions Using Linear Equations
 
 Sometimes you're given a linear equation in one variable and asked to evaluate a *different* expression containing that variable. You can solve for the variable first and substitute it in, or — often faster — recognize the relationship between the equation and the expression and substitute directly.
@@ -130,8 +121,6 @@ Sometimes you're given a linear equation in one variable and asked to evaluate a
 > = 4(5) \\
 > = 20
 >$$
-
----
 
 ## Linear Inequalities
 
@@ -159,8 +148,6 @@ Solving inequalities works the same way as solving equations, with one key diffe
 >
 > Checking $x=-3$ (which satisfies $x < -2$): $-2(-3)+1=7>5$ ✓. Checking $x=1$ (which does not): $-2(1)+1=-1$, and $-1\ngtr 5$.
 
----
-
 ## How Many Solutions Can a Linear Equation Have?
 
 Most linear equations have exactly one solution. But an equation can also have **no solution** or **infinitely many solutions**, depending on how its constants are set up:
@@ -176,8 +163,6 @@ Most linear equations have exactly one solution. But an equation can also have *
 **2. In the equation $2x-4=a(x-2)$, if $a=2$, what value of $x$ satisfies the equation?**
 
 > **Solution:** Substituting $a=2$ gives $2x-4=2(x-2)=2x-4$. Adding $4$ to both sides leaves $2x=2x$, which is always true — so **all real values of $x$ satisfy the equation**.
-
----
 
 ## Things to Remember
 

--- a/content/1_Foundations/Pigeonhole_Principles.mdx
+++ b/content/1_Foundations/Pigeonhole_Principles.mdx
@@ -10,8 +10,6 @@ prerequisites: [counting-fundamentals, stars-and-bars]
  
 The Pigeonhole Principle states that if you have more objects than containers, at least one container must hold
 more than one object.
- 
----
 
 ## Key Ideas
  
@@ -60,8 +58,6 @@ This is in cases, cleaner than actually invoking the ceiling formula directly.
 An example of this would be when five numbers sum to $51$. Since the average is $\frac{51}{5} = 10.2$,
 hence at least one number is $\geq 11$. 
  
----
- 
 ## Worked Example
  
 Show that among any $5$ integers, two must have the same
@@ -70,8 +66,6 @@ remainder when divided by $4$.
 There are only $4$ possible remainders mod $4$: $\{0, 1, 2, 3\}$. These are the "holes", and the $5$ integers are the pigeons. Since $5 > 4$, by the Pigeonhole Principle, at least two integers share
 a remainder. Their difference is therefore divisible by $4$. $\blacksquare$
  
- 
----
  
 ## More Examples
  
@@ -83,8 +77,6 @@ The colors are the holes: $3$ holes. Each sock drawn is a pigeon. We know that b
  
 Answer: $\boxed{4}$.
  
- 
----
  
 ### Example 2 — The Generalized Pigeonhole (Or extended)
  

--- a/content/1_Foundations/Recursion_Basics.mdx
+++ b/content/1_Foundations/Recursion_Basics.mdx
@@ -152,8 +152,6 @@ $$
 
 </Spoiler>
 
----
-
 **Problem 2.** A sequence starts with 1, 1, and each new term is the sum of the two before it. What is the 9th term?
 
 <Spoiler>
@@ -165,8 +163,6 @@ $$
 $$
 
 </Spoiler>
-
----
 
 **Problem 3.** How many ways can you tile a $2 \times 5$ grid using only $1 \times 2$ dominoes placed horizontally or vertically?
 
@@ -182,8 +178,6 @@ $$
 
 </Spoiler>
 
----
-
 **Problem 4.** You are climbing stairs and can take 1, 2, or 3 steps at a time. How many ways can you reach step 7?
 
 <Spoiler>
@@ -197,8 +191,6 @@ f(4)=7,\quad f(5)=13,\quad f(6)=24,\quad f(7)=\boxed{44}
 $$
 
 </Spoiler>
-
----
 
 **Problem 5.** A bug walks on a number line starting at 0. Each second it moves $+1$ or $-1$. How many paths of length 6 return the bug to 0 at the end?
 
@@ -214,8 +206,6 @@ This also follows from the recursion $f(n,k) = f(n-1,k-1)+f(n-1,k+1)$ with $f(0,
 
 </Spoiler>
 
----
-
 **Problem 6.** How many strings of length 8 made of only A and B contain no two consecutive B's?
 
 <Spoiler>
@@ -229,8 +219,6 @@ f(3)=5,\quad f(4)=8,\quad\ldots\quad f(8)=\boxed{55}
 $$
 
 </Spoiler>
-
----
 
 **Problem 7.** On a $3 \times 3$ grid of unit squares, how many paths go from the bottom-left corner to the top-right corner using only unit moves right and up, if the lattice point $(1, 2)$ is blocked and cannot be visited?
 
@@ -252,8 +240,6 @@ $$
 The top-right entry is $\boxed{11}$. (Check: all $\binom{6}{3}=20$ paths, minus the $\binom{3}{1}\binom{3}{1}=9$ that pass through $(1,2)$, gives $20-9=11$.)
 
 </Spoiler>
-
----
 
 **Problem 8.** A staircase has 8 steps, but step 5 is cracked and cannot be landed on. You may still pass over it with a 2-step. Climbing 1 or 2 steps at a time, how many ways can you reach step 8?
 

--- a/content/1_Foundations/Right_Triangles.mdx
+++ b/content/1_Foundations/Right_Triangles.mdx
@@ -111,8 +111,6 @@ Created by cutting an equilateral triangle exactly in half down its altitude.
   </svg>
 </div>
 
----
-
 ## Worked Examples
 
 ### Example 1: Cascading Triangles

--- a/content/1_Foundations/Triangle_Congruence_Similarity.mdx
+++ b/content/1_Foundations/Triangle_Congruence_Similarity.mdx
@@ -245,8 +245,6 @@ Setting up the proportions yields two incredibly useful formulas:
 1. $CD^2 = AD \cdot BD$ (The altitude is the geometric mean of the two hypotenuse segments).
 2. $AC^2 = AD \cdot AB$ (A leg is the geometric mean of the adjacent segment and the whole hypotenuse).
 
----
-
 ## Worked Examples
 
 ### Example 1: Nested Triangles and Area

--- a/content/1_Foundations/Word_Problems.mdx
+++ b/content/1_Foundations/Word_Problems.mdx
@@ -34,8 +34,6 @@ A linear relationship is any relationship between two variables that creates a l
 > \end{aligned}
 > $$
 
----
-
 ## Linear relationships
 
 Linear equations can be used to represent the relationship between two variables, most commonly $x$ and $y$. To form the simplest linear relationship, we can make our two variables equal:
@@ -56,8 +54,6 @@ By plugging numbers into the equation, we can find some relative values of $x$ a
 If we plot those points in the $xy$-plane, we create a line. The equation $y=x$ is graphed in the $xy$-plane, with the points $(0,0)$, $(1,1)$, $(2,2)$, and $(3,3)$
 
 Every possible linear relationship is just a modification of this simple equation. We might multiply one of the variables by a coefficient or add a constant to one side of the equation, but we'll still be creating a linear relationship.
-
----
 
 ## How do we translate word problems into linear equations?
 
@@ -136,8 +132,6 @@ It may not be hard to translate "Maya is $3$ inches taller than Geoff" into a li
 >
 > The concession stand sold $28$ bags of peanuts.
 
----
-
 ## Linear functions
 
 Any linear equation with two variables is technically a function. Linear functions are usually written in either slope-intercept form or standard form. We need a thorough and flexible understanding of these forms in order to approach many  questions about linear relationships.
@@ -169,8 +163,6 @@ The slope-intercept form of a linear function, $y=mx+b$, where $m$ and $b$ are c
 ### Standard form
 
 The standard form of a linear function, $Ay+Bx=C$, where $A$, $B$, and $C$ are constants, will often be used in word problem scenarios that have two inputs, instead of an input and an output. To find the slope or $y$-intercept of a line in standard form, it's often most convenient to convert the equation to slope-intercept form by isolating $y$.
-
----
 
 ## More Word-Problem Patterns
 
@@ -239,8 +231,6 @@ A common trap: successive percent changes **multiply**, they don't add or cancel
 > $$
 >
 > A result of $0.96$ means the final price is $96\%$ of the original — a net **$4\%$ decrease**, not $0\%$. This happens because the second decrease of $20\%$ is taken from the already-increased (larger) price, so it removes more than the first increase added.
-
----
 
 
 ## Things to Remember

--- a/content/2_Intermediate/Advanced_Counting.mdx
+++ b/content/2_Intermediate/Advanced_Counting.mdx
@@ -19,8 +19,6 @@ the bad cases (inclusion-exclusion), or use symmetry to collapse the count
 
 This module covers the core techniques, strategies, and the classical structures that appear, to give an understanding of advanced casework. 
 
----
-
 First, we recap some basic counting techniques. 
 
 ## Inclusion-Exclusion
@@ -101,8 +99,6 @@ to some position $k \ne 1$, and then either element $k$ goes to position $1$
 
 As $n \to \infty$, $D_n/n! \to 1/e \approx 0.368$. Something that is not necessary to know but is useful information is that for any large $n$, about $36.8\%$ of all permutations are derangements.
 
----
-
 ## Bijections and Double Counting
 
 ### Bijections
@@ -135,8 +131,6 @@ $$
 Since these are equal, we prove Vandermonde's identity in the symmetric case.
 
 There are many other standard ways to do this.
-
----
 
 ## Catalan Numbers
 
@@ -196,7 +190,6 @@ $$
 C_n=\frac{1}{n+1}\binom{2n}{n}.
 $$
 
----
 ## Solving Linear Recurrences
 
 Furthermore, linear recurrences with constant coefficients are another type of difficult competition problem.
@@ -245,8 +238,6 @@ F_n
 $$
 
 These are often for more complex problems, but it may be fruitful to know.
-
----
 
 ## Examples
 
@@ -303,8 +294,6 @@ $$
 90-60=\mathbf{30}.
 $$
 
----
-
 ### Example 2: Derangements
 
 **Problem.** Five students each write their name on a card, then the cards
@@ -330,8 +319,6 @@ Probability is therefore
 $$
 \frac{44}{120}=\mathbf{\frac{11}{30}}.
 $$
-
----
 
 ### Example 3: Catalan Numbers 
 
@@ -360,8 +347,6 @@ C_5
 =
 \mathbf{42}.
 $$
-
----
 
 ### Example 4: Recursion 
 
@@ -393,8 +378,6 @@ f(9)&=55, \\
 f(10)&=\mathbf{89}.
 \end{aligned}
 $$
-
----
 
 ## Practice Problems
 

--- a/content/2_Intermediate/Arc_and_Chord.mdx
+++ b/content/2_Intermediate/Arc_and_Chord.mdx
@@ -54,8 +54,6 @@ $$
 
 A diameter divides a circle into two semicircles, each measuring $180^\circ$. Any chord between the endpoints of a diameter is the longest possible chord.
 
----
-
 ## Angle Theorems
 
 ### Inscribed Angle Theorem
@@ -234,8 +232,6 @@ $$
 
 This is also called the **tangent-chord angle** or **alternate segment theorem**. It appears frequently in problems where a tangent is drawn at one end of a chord.
 
----
-
 ## Tangent Theorems
 
 ### Radius to Tangent is Perpendicular
@@ -259,8 +255,6 @@ PT_1 = PT_2.
 $$
 
 The triangles $OT_1P$ and $OT_2P$ are congruent (hypotenuse $OP$ and equal radii $OT_1 = OT_2$, with right angles at the touch points), giving the result immediately.
-
----
 
 ## Chord Intersection Theorems
 
@@ -345,15 +339,11 @@ $$
 
 This can be seen as the limiting case of the secant-secant theorem when the two intersection points of one secant merge into a single tangent point.
 
----
-
 ## Chords and Symmetry
 
 If a radius is drawn perpendicular to a chord, then it bisects the chord. Conversely, if a radius bisects a chord, it is perpendicular to the chord:
 
 > A radius perpendicular to a chord bisects the chord.
-
----
 
 ## Arc Length
 
@@ -364,8 +354,6 @@ s = r\theta.
 $$
 
 Always convert degrees to radians before applying this formula. For example, $60° = \pi/3$.
-
----
 
 ## Worked Examples
 
@@ -426,8 +414,6 @@ A radius bisects a chord of length $12$. Each half has length $6$.
 ### Example: Semicircle Arc Length
 
 A circle has radius $8$. The semicircular arc length is $s = 8\pi$.
-
----
 
 ## Strategy Checklist
 

--- a/content/2_Intermediate/Barycentric_Coordinates.mdx
+++ b/content/2_Intermediate/Barycentric_Coordinates.mdx
@@ -165,8 +165,6 @@ Taking the "Swap" ratios for each side:
 $$\frac{BD}{DC} = \frac{z}{y}, \quad \frac{CE}{EA} = \frac{x}{z}, \quad \frac{AF}{FB} = \frac{y}{x}$$
 Multiplying them together gives $\frac{z}{y} \cdot \frac{x}{z} \cdot \frac{y}{x} = 1$. The algebra natively guarantees the geometry!
 
----
-
 ## 5. A Contest Playbook
 
 When should you actually use Barycentric Coordinates during a high-stakes exam?
@@ -183,8 +181,6 @@ When should you actually use Barycentric Coordinates during a high-stakes exam?
 * Circle geometry or angle-chasing dominates the problem (concyclic points are terrible in barycentrics).
 * The problem relies heavily on perpendicularity and lengths, but isn't tied to the orthocenter.
 * A Cartesian coordinate plane system is already simpler (e.g., right triangles resting on the $x$-axis).
-
----
 
 ## Worked Examples
 

--- a/content/2_Intermediate/Binomial_Theorem_p1.mdx
+++ b/content/2_Intermediate/Binomial_Theorem_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: binomial-theorem-p1
-title: Binomial Theorem (Part 1)
+title: Binomial Theorem I
 author: Neronvain
 description: Learn how the Binomial Theorem expands powers, explains binomial coefficients, and connects algebraic expressions with counting and probability.
 prerequisites: []

--- a/content/2_Intermediate/Binomial_Theorem_p2.mdx
+++ b/content/2_Intermediate/Binomial_Theorem_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: binomial-theorem-p2
-title: Binomial Theorem (Part 2)
+title: Binomial Theorem II
 author: Neronvain
 description: Learn how the Binomial Theorem expands powers, explains binomial coefficients, and connects algebraic expressions with counting and probability.
 prerequisites: []

--- a/content/2_Intermediate/Block_Walk.mdx
+++ b/content/2_Intermediate/Block_Walk.mdx
@@ -32,8 +32,6 @@ The technique converts a question about a long sequence into a question about a 
   Illustration: A row of 13 colored squares (three white, two black, one white, three black, two white, two black) separated by vertical dividers at each color change. Each maximal consecutive run of the same color is labeled as a block (Block 1, Block 2, …, Block 6). Arrows point to the five dividers and label them as boundaries. The diagram should make visually clear that the number of boundaries is always one less than the number of blocks.
 </FigureBox>
 
----
-
 ## 2. Core Idea
 
 ### Definitions
@@ -60,8 +58,6 @@ Let $B$ denote the number of blocks in a sequence. Then:
 <FigureBox image="/images/block-boundaries.png" alt="Diagram labeling blocks, boundaries, and transitions in a binary sequence" title="Blocks, boundaries, and transitions">
   Illustration: A horizontal strip representing the binary string $11000110111$. Blocks are shaded in alternating light/dark bands. Vertical tick marks at each boundary are labeled $T_1, T_2, \ldots, T_{B-1}$. The leftmost position is labeled "left endpoint" and the rightmost "right endpoint." A small table below maps: number of blocks $B = 5$, number of boundaries $= 4$, number of transitions $= 4$. This should clearly distinguish blocks (regions) from boundaries (dividers) from transitions (events).
 </FigureBox>
-
----
 
 ## 3. Simple Motivating Example
 
@@ -99,8 +95,6 @@ The block walk formulation made it immediately clear what variables to introduce
 
 > **Answer:** There are $84$ binary strings of length 8 with exactly 3 runs of 1s.
 
----
-
 ## 4. General Block Walk Principle
 
 **General Principle.** *If a problem involves a sequence where the relevant structure is determined by how many times the sequence changes type, not by the exact values, then compress the sequence into its block walk and count or reason about blocks and transitions instead.*
@@ -127,8 +121,6 @@ The block walk formulation made it immediately clear what variables to introduce
 **Parity changes.** A sequence $(a_1, \ldots, a_n)$ of integers has exactly $k$ parity changes if and only if there are exactly $k$ indices $i$ where $a_i \not\equiv a_{i+1} \pmod{2}$. Parity-change counting is a standard technique in olympiad problems about integer sequences.
 
 **Lattice paths.** A path from $(0,0)$ to $(m, n)$ using East (E) and North (N) steps can be encoded as a binary string. A block walk on this string corresponds to alternating runs of E-steps and N-steps; the number of direction changes equals $B - 1$ where $B$ is the number of runs.
-
----
 
 ## 5. Worked Example 1: Binary Strings
 
@@ -168,8 +160,6 @@ By thinking of a binary string as a sequence of $B$ blocks determined by choosin
   Illustration: A binary string of length 12, displayed as a row of squares labeled 0 or 1. Alternating runs are shaded light (0-runs) and dark (1-runs). Below the string, the 11 gaps between adjacent positions are shown as tick marks, and the gaps chosen as boundaries (for an example with 5 runs) are marked with vertical bars. A label reads: "Choosing $B-1 = 4$ boundary positions from 11 gaps gives $\binom{11}{4}$ strings with 5 runs starting with 0." A second row shows the same string starting with 1.
 </FigureBox>
 
----
-
 ## 6. Worked Example 2: Parity Changes
 
 ### Problem
@@ -197,8 +187,6 @@ This is a clean example of a block walk argument: by compressing the sequence in
 <FigureBox image="/images/parity-transition-example.png" alt="Sequence partitioned into even and odd blocks with parity transitions marked" title="Parity blocks and transitions">
   Illustration: A sequence of 10 integers, some even (shaded blue) and some odd (shaded orange), arranged in a row. Vertical dividers mark parity transitions. Below each block, the block's parity (E or O) is labeled. An arrow from the first block's parity label to the last block's parity label is annotated: "Same parity iff $B$ is odd iff $k = B - 1$ is even." A small 2-row table shows: $B = 4 \Rightarrow k = 3$ (odd) $\Rightarrow$ endpoints have different parity; $B = 5 \Rightarrow k = 4$ (even) $\Rightarrow$ endpoints have same parity.
 </FigureBox>
-
----
 
 ## 7. Worked Example 3: USAMO-Style Proof Problem
 
@@ -236,8 +224,6 @@ This is a common olympiad pattern: a condition on contiguous sums forces the blo
 <FigureBox image="/images/usamo-block-walk-proof.png" alt="Diagram illustrating why a balanced sequence must alternate" title="Block walk proof: balanced forces alternating">
   Illustration: Two side-by-side sequences of length 6. Left: a non-alternating sequence with $a_3 = a_4 = +1$ highlighted in red, with a bracket below showing $a_3 + a_4 = 2 > 1$, labeled "NOT balanced." Right: a fully alternating sequence $+1, -1, +1, -1, +1, -1$ with all adjacent pairs connected by arrows labeled "$\neq$", labeled "Balanced." Below each, the block walk is shown: the left has a block of length 2 highlighted; the right has all blocks of length 1.
 </FigureBox>
-
----
 
 ## 8. Common Patterns
 
@@ -287,8 +273,6 @@ When a sequence is modified by an operation (e.g., inserting an element, flippin
 
 Invariant arguments about $B$ modulo some number are common in olympiad problems about sequence operations.
 
----
-
 ## 9. Common Mistakes
 
 ### Mistake 1: Forgetting Endpoints
@@ -331,8 +315,6 @@ Invariant arguments about $B$ modulo some number are common in olympiad problems
 
 **Fix.** State your block definition precisely at the start of the solution and use it consistently throughout.
 
----
-
 ## 10. Practice Problems
 
 ### Easy
@@ -355,8 +337,6 @@ $$\sum_{i=1}^{j} x_i \geq 0 \quad (1 \leq j \leq 2n), \qquad \sum_{i=1}^{2n}x_i=
 
 Prove that in every good sequence, the number of $+1$-blocks equals the number of $-1$-blocks. Also prove that this common number is equal to the number of peaks of the partial-sum path, where a peak is an index $j$ such that $x_j=+1$ and $x_{j+1}=-1$.
 
----
-
 ## 11. Hints
 
 **Hint for Problem 1.** A string with exactly 4 blocks of 0s has either 3, 4, or 5 blocks of 1s depending on whether the string starts and ends with 0 or 1. Count each endpoint case separately.
@@ -368,8 +348,6 @@ Prove that in every good sequence, the number of $+1$-blocks equals the number o
 **Hint for Problem 4.** Since the string starts and ends with 1 and has exactly 4 1-blocks, it must have exactly 3 0-blocks. Write the block structure explicitly, then use stars and bars.
 
 **Hint for Problem 5.** A good sequence must start with $+1$ and end with $-1$. Then use the fact that blocks alternate. A peak occurs exactly at the end of a $+1$-block.
-
----
 
 ## 12. Solutions
 
@@ -532,8 +510,6 @@ First, the sequence must start with $+1$, because otherwise $S_1=-1<0$. It must 
 Now compress the sequence into blocks of consecutive equal signs. Since the sequence starts with a $+1$-block and ends with a $-1$-block, and since block signs alternate, the number of $+1$-blocks equals the number of $-1$-blocks.
 
 Finally, a peak of the partial-sum path occurs exactly when the path takes a $+1$ step followed immediately by a $-1$ step. In the original sequence, that is exactly a transition from a $+1$-block to the next $-1$-block. Such a transition occurs once at the end of every $+1$-block. Therefore the number of peaks equals the number of $+1$-blocks, which also equals the number of $-1$-blocks. $\blacksquare$
-
----
 
 ## 13. Summary
 

--- a/content/2_Intermediate/Complex_Basics.mdx
+++ b/content/2_Intermediate/Complex_Basics.mdx
@@ -160,8 +160,6 @@ $$
 
 not $-7i$.
 
----
-
 ## Powers of $i$
 
 If we keep multiplying $i$ by itself, we get a cycle that repeats every $4$ steps:
@@ -280,8 +278,6 @@ where the remainder is taken in $\{0,1,2,3\}$ and $i^0=1$.
 
 The mod-$4$ trick is mechanical once you see it — and it appears on AMC/AIME more often than you'd expect.
 
----
-
 ## Algebra of Complex Numbers
 
 ### Addition and Subtraction
@@ -378,8 +374,6 @@ $$
 y=-\frac{23}{13}
 $$
 
----
-
 ## Conjugates
 
 The **conjugate** of
@@ -427,8 +421,6 @@ $$
 $$
 \overline{zw}=\overline{z}\,\overline{w}
 $$
-
----
 
 ## Division
 
@@ -562,8 +554,6 @@ $$
 =
 -\frac{5}{17}+\frac{14}{17}i
 $$
-
----
 
 ## Worked Examples
 
@@ -707,8 +697,6 @@ $$
 > z=-1-i
 > $$
 
----
-
 ## Strategy Checklist
 
 | Task | Technique |
@@ -720,8 +708,6 @@ $$
 | Relate $z$ and $\overline{z}$ | Use $z\overline{z}=a^2+b^2$ |
 | Solve equations like $z^2=w$ | Write $z=a+bi$ and equate parts |
 
----
-
 ## Common Pitfalls
 
 - Treating $\operatorname{Im}(z)$ as $bi$ instead of $b$
@@ -730,8 +716,6 @@ $$
 - Confusing $z+\overline{z}$ with $2|z|$
 - Forgetting to multiply numerator *and* denominator by the conjugate
 - Changing the sign of the real part when conjugating
-
----
 
 ## Remarks
 

--- a/content/2_Intermediate/Complex_Plane.mdx
+++ b/content/2_Intermediate/Complex_Plane.mdx
@@ -60,8 +60,6 @@ Some notation to lock in immediately:
 - $\text{Im}(z)$ denotes the imaginary part (the coefficient of $i$, which is a real number). So $\text{Im}(2 - 4i) = -4$.
 - Some sources write $\mathcal{R}(z)$ and $\mathcal{I}(z)$ for these same quantities.
 
----
-
 ## Conjugate and Negation: Geometric Meaning
 
 For $z = a + bi$, recall the two cousins: $\bar{z} = a - bi$ (conjugate) and $-z = -a - bi$ (negation). Their algebraic definitions are easy, but the Argand plane reveals their geometry instantly.
@@ -115,8 +113,6 @@ $$
 
 These identities convert between expressions in $z, \bar{z}$ and geometric constraints on $\text{Re}(z), \text{Im}(z)$ — extremely useful for graphing.
 
----
-
 ## Complex Numbers as Vectors
 
 Every complex number $z = a + bi$ corresponds to a point $(a, b)$, but also to the **vector** $\langle a, b \rangle$ from the origin to that point. Both views pay dividends.
@@ -158,8 +154,6 @@ Every complex number $z = a + bi$ corresponds to a point $(a, b)$, but also to t
 </div>
 
 The subtraction $w - z$ also has a clean geometric meaning: it is the vector **from $z$ to $w$**. This connects directly to distance.
-
----
 
 ## Magnitude
 
@@ -215,8 +209,6 @@ The last two say magnitude is **multiplicative** — one of its most useful prop
 
 > **Competition tip**: When asked for $|f(z)|$ where $f$ is a product or quotient, split the magnitude immediately rather than expanding. $|(1+i)^{10}| = |1+i|^{10} = (\sqrt{2})^{10} = 32$ in two steps.
 
----
-
 ## Distance in the Complex Plane
 
 The distance between two complex numbers $w$ and $z$ equals $|w - z|$.
@@ -238,8 +230,6 @@ $$
 **Midpoint formula**: The midpoint of the segment joining $z_1$ and $z_2$ is $\dfrac{z_1 + z_2}{2}$.
 
 *Why?* The midpoint of $(a_1,b_1)$ and $(a_2,b_2)$ is $\left(\dfrac{a_1+a_2}{2}, \dfrac{b_1+b_2}{2}\right)$, which corresponds exactly to $\dfrac{z_1+z_2}{2}$. $\blacksquare$
-
----
 
 ## Graphing Equations in the Complex Plane
 
@@ -323,8 +313,6 @@ A line, as expected.
 
 **General principle**: Complex number equations have both algebraic and geometric readings. When the algebra looks messy, switch to the geometric picture. When the geometry is unclear, write $z = a + bi$ and expand.
 
----
-
 ## Perpendicularity and the Imaginary Quotient
 
 A beautiful fact connects geometry to complex division:
@@ -340,8 +328,6 @@ $$
 This is zero exactly when the dot product is zero. And $\text{Re}(w/z) = 0$ is exactly the condition for $w/z$ to be purely imaginary. $\blacksquare$
 
 Likewise, $w \parallel z$ (same or opposite direction) if and only if $w/z$ is **purely real**.
-
----
 
 ## Worked Examples
 
@@ -361,8 +347,6 @@ Likewise, $w \parallel z$ (same or opposite direction) if and only if $w/z$ is *
 >
 > Distance between $4 + 7i$ and $-3 - 17i$:
 > $$|(4+7i) - (-3-17i)| = |7 + 24i| = \sqrt{49 + 576} = \sqrt{625} = 25$$
-
----
 
 ## Summary
 

--- a/content/2_Intermediate/Complex_Polar_Form.mdx
+++ b/content/2_Intermediate/Complex_Polar_Form.mdx
@@ -22,8 +22,6 @@ The central insight: **multiplication in polar form is rotation and scaling.**
   A point $z = a + bi$ sits at distance $r = |z|$ from the origin. The angle from the positive real axis, measured counterclockwise, is $\theta = \arg(z)$. These two quantities, the modulus and argument, completely determine $z$.
 </FigureBox>
 
----
-
 ## 2. Polar Form
 
 For any nonzero $z = a + bi$, define:
@@ -49,8 +47,6 @@ $$z = re^{i\theta} \qquad \text{(exponential form, via Euler's formula)}$$
 | $-i$ | $1$ | $-\pi/2$ | $e^{-i\pi/2}$ |
 | $-3$ | $3$ | $\pi$ | $3e^{i\pi}$ |
 
----
-
 ## 3. Geometry of Multiplication
 
 For $z_1 = r_1 e^{i\alpha}$ and $z_2 = r_2 e^{i\beta}$:
@@ -72,8 +68,6 @@ Dividing by $z_2$ rotates **clockwise** by $\arg(z_2)$ and scales by $1/|z_2|$.
 **Key principle:** Multiplying any complex number by a unit complex number $e^{i\theta}$ rotates it by $\theta$ about the origin. To rotate a point $z$ about a center $c$ by angle $\theta$, compute:
 
 $$z' = e^{i\theta}(z - c) + c$$
-
----
 
 ## 4. Rotations
 
@@ -103,8 +97,6 @@ This converts an equilateral triangle condition into a single complex multiplica
   The triangle $ABC$ is equilateral if and only if $C - A = e^{i\pi/3}(B-A)$ or $C - A = e^{-i\pi/3}(B-A)$. Two orientations, one formula.
 </FigureBox>
 
----
-
 ## 5. De Moivre's Theorem
 
 **Theorem.** For any integer $n$:
@@ -122,8 +114,6 @@ This method generates all multiple-angle formulas mechanically.
 <FigureBox image="/images/demoivre-powers.png" alt="Sequence of unit complex numbers e^(i theta), e^(2i theta), e^(3i theta) equally spaced around the unit circle" title="Powers of a Unit Complex Number">
   Repeated multiplication by $e^{i\theta}$ steps around the unit circle in equal angular increments. After $n$ steps, you land at $e^{in\theta}$: this is De Moivre's theorem made visual.
 </FigureBox>
-
----
 
 ## 6. De Moivre Bashing
 
@@ -157,8 +147,6 @@ $(2+2i) = 2\sqrt{2}\,e^{i\pi/4}$, so $(2+2i)^8 = (2\sqrt{2})^8 e^{2\pi i} = 2^{1
 
 If $\omega = e^{2\pi i/n}$, then $\omega^n = 1$ and $1 + \omega + \omega^2 + \cdots + \omega^{n-1} = 0$. This identity is the key to the roots-of-unity filter technique.
 
----
-
 ## 7. Roots of Complex Numbers
 
 To solve $z^n = w$ where $w = \rho e^{i\phi}$:
@@ -176,8 +164,6 @@ There are exactly $n$ roots, evenly spaced at angles $2\pi/n$ apart on a circle 
 </FigureBox>
 
 **Key fact.** The roots of $z^n = 1$ are $e^{2\pi i k/n}$ for $k = 0, \ldots, n-1$. These are the vertices of a regular $n$-gon centered at the origin with one vertex at $1$.
-
----
 
 ## 8. Common Olympiad Techniques
 
@@ -200,8 +186,6 @@ There are exactly $n$ roots, evenly spaced at angles $2\pi/n$ apart on a circle 
 **Technique 7: Convert geometry into multiplication.** Collinearity, perpendicularity, concyclicity, and angle bisectors all have clean complex-number characterizations. Three points $A, B, C$ are collinear iff $\frac{C-A}{B-A} \in \mathbb{R}$. They are concyclic iff $\frac{(C-A)(D-B)}{(C-B)(D-A)} \in \mathbb{R}$.
 
 **Technique 8: Use arguments to prove collinearity and cyclicity.** $\arg\!\left(\frac{z_2 - z_1}{z_3 - z_1}\right) = 0$ or $\pi$ means $z_1, z_2, z_3$ are collinear. Four points are concyclic iff $\arg\!\left(\frac{z_3 - z_1}{z_3 - z_2}\right) \equiv \arg\!\left(\frac{z_4 - z_1}{z_4 - z_2}\right) \pmod{\pi}$, i.e., the inscribed angles subtended by chord $z_1 z_2$ from $z_3$ and $z_4$ agree modulo $\pi$. This is equivalent to Technique 7's cross-ratio condition.
-
----
 
 ## 9. Worked AIME-Style Problems
 
@@ -238,8 +222,6 @@ Therefore $|S|^2=S\bar{S}=\boxed{2}$.
 
 *Solution.* Use the product-to-sum identity to get $\frac{1}{2}\sum_{k=1}^{12}\cos\!\left(\frac{6\pi k}{13}\right) + \frac{1}{2}\sum_{k=1}^{12}\cos\!\left(\frac{2\pi k}{13}\right)$. Each sum equals $\text{Re}\!\left(\sum_{k=1}^{12}\omega^{3k}\right)$ or $\text{Re}\!\left(\sum_{k=1}^{12}\omega^k\right)$ for $\omega = e^{2\pi i/13}$. Since neither exponent is divisible by 13, both geometric sums equal $-1$. Answer: $-1$.
 
----
-
 ## 10. Proof Problems
 
 **Problem 1.** Let $A$, $B$, $C$ be the vertices of an equilateral triangle in the complex plane. Prove that $A^2 + B^2 + C^2 = AB + BC + CA$.
@@ -268,8 +250,6 @@ Multiply $z_1+z_2+z_3 = 0$ by $\bar{z}_1$ to get $1 + z_2\bar{z}_1 + z_3\bar{z}_
 
 *Solution.* $(\Rightarrow)$ The circumcenter of any triangle inscribed in the unit circle is the origin. For an equilateral triangle, the circumcenter coincides with the centroid, so the centroid is at the origin. The triangle is therefore invariant under $120^\circ$ rotation about the origin, meaning $\{P,Q,R\} = \{P, e^{2\pi i/3}P, e^{4\pi i/3}P\}$. In either orientation, $Q^3 = e^{\pm 2\pi i}P^3 = P^3$ and $R^3 = e^{\pm 4\pi i}P^3 = P^3$. $(\Leftarrow)$ If $P^3 = Q^3 = R^3 = c$ with $|c|=1$, then $P$, $Q$, $R$ are three distinct cube roots of $c$. The cube roots of any $c$ on the unit circle are equally spaced at $120^\circ$, forming an equilateral triangle. $\square$
 
----
-
 ## 11. Common Mistakes
 
 **Forgetting multiple arguments.** The argument of $z$ is $\theta + 2\pi k$, not just $\theta$. When taking $n$th roots, each value of $k$ from $0$ to $n-1$ gives a distinct root. Missing any of them loses points.
@@ -283,8 +263,6 @@ Multiply $z_1+z_2+z_3 = 0$ by $\bar{z}_1$ to get $1 + z_2\bar{z}_1 + z_3\bar{z}_
 **Incorrect angle arithmetic.** When computing $e^{i\theta} \cdot e^{i\phi} = e^{i(\theta+\phi)}$, be careful about angle reduction modulo $2\pi$. The form $re^{i\theta}$ is not unique unless you fix a range for $\theta$.
 
 **Forgetting conjugates on the unit circle.** If $|z| = 1$, then $\bar{z} = 1/z$, not just $\overline{a+bi} = a - bi$. Using this saves enormous computation.
-
----
 
 ## 12. Practice Problems
 
@@ -307,8 +285,6 @@ Multiply $z_1+z_2+z_3 = 0$ by $\bar{z}_1$ to get $1 + z_2\bar{z}_1 + z_3\bar{z}_
 9. Prove that the product of all distances from $1$ to the other $n$th roots of unity equals $n$.
 10. Find all $z$ on the unit circle such that $z^n + \bar{z}^n$ is an integer for every positive integer $n$.
 
----
-
 ## 13. Hints
 
 1. Convert to polar form: $1 + i\sqrt{3} = 2e^{i\pi/3}$.
@@ -321,8 +297,6 @@ Multiply $z_1+z_2+z_3 = 0$ by $\bar{z}_1$ to get $1 + z_2\bar{z}_1 + z_3\bar{z}_
 8. Consider the polynomial with roots $\omega^k + \omega^{9-k}$ and use Vieta's or the minimal polynomial of $2\cos(2\pi/9)$.
 9. Factor $z^n - 1 = \prod_{k=0}^{n-1}(z - \omega^k)$ and set $z = 1$ after canceling the $k=0$ factor.
 10. Write $z = e^{i\theta}$; then $z^n + \bar{z}^n = 2\cos(n\theta)$. Consider when $2\cos(n\theta) \in \mathbb{Z}$ for all $n$.
-
----
 
 ## 14. Solutions
 
@@ -365,8 +339,6 @@ shows by induction that $2\cos(n\theta)$ is an integer for all positive integers
 $$z\in\{1,e^{\pm i\pi/3},\pm i,e^{\pm 2i\pi/3},-1\}.$$
 
 These are exactly the sixth roots of unity together with $\pm i$.
-
----
 
 ## 15. Summary
 

--- a/content/2_Intermediate/Function_Basics_p1.mdx
+++ b/content/2_Intermediate/Function_Basics_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: function-basics-p1
-title: Function Basics Part 1
+title: Function Basics I
 author: Pranav Ramesh
 description: All about Polynomials and Ideas used in solving them.
 prerequisites: ["algebra-basics"]
@@ -48,8 +48,6 @@ $$
 
 The distinction between codomain and range trips people up. If $f : \mathbb{R} \to \mathbb{R}$ is defined by $f(x) = x^2$, the codomain is $\mathbb{R}$ but the range is $[0, \infty)$.
 
----
-
 ## Is It Even a Function? The Validity Test
 
 Not every rule or curve defines a function. Before you can even talk about domain and range, you need to check whether it's a function at all !!!
@@ -78,8 +76,6 @@ Here are some examples to understand this concept.
 - Parabola $y = x^2$: passes since each vertical line hits at exactly one point.
 - The upper semicircle $y = \sqrt{1 - x^2}$: passes since taking only positive $y$ removes the ambiguity of double roots.
 
----
-
 ## Finding Domain and Range: General Strategy
 
 **Finding the domain** (algebraic approach): Start with all real numbers and remove values of $x$ that cause problems:
@@ -97,8 +93,6 @@ Here are some examples to understand this concept.
 *Method 3 : Calculus / monotonicity.* If f is monotone on its domain, the range is the interval [f(left endpoint), f(right endpoint)] or similar.
 
 For competition problems, Method 1 is usually the best.
-
----
 
 ## Types of Functions: Domain and Range in Detail
 
@@ -285,8 +279,6 @@ For transformed sinusoids $f(x) = A\sin(Bx + C) + D$:
 - **Range**: $[D - |A|,\ D + |A|]$
 
 **Example:** Range of $f(x) = 3\sin(2x - \pi) + 1$. Here $A = 3$, $D = 1$. Range: $[1 - 3, 1 + 3] = [-2, 4]$.
-
----
 
 # Part 2 
 Graphical Representation, Transformations, Composite, and Inverse Functions are continued in part 2. 

--- a/content/2_Intermediate/Function_Basics_p2.mdx
+++ b/content/2_Intermediate/Function_Basics_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: function-basics-p2
-title: Function Basics Part 2
+title: Function Basics II
 author: Pranav Ramesh
 description: All about Polynomials and Ideas used in solving them.
 prerequisites: ["algebra-basics", "function-basics-p1"]
@@ -42,8 +42,6 @@ Every transformation of $f(x)$ has a precise graphical effect. The following are
 4. $\to -2\sqrt{x+3} + 1$: shift up by $1$.
 
 Vertex moves from $(0, 0)$ to $(-3, 1)$; graph opens downward. Range: $(-\infty, 1]$.
-
----
 
 ## Composition of Functions
 
@@ -92,8 +90,6 @@ The domain of $f \circ g$ is the set of all $x$ in the domain of $g$ such that $
 $D_g = (-\infty, \infty)$. For $f$, we need $g(x) \geq 0$: $1 - x^2 \geq 0 \Rightarrow x^2 \leq 1 \Rightarrow -1 \leq x \leq 1$.
 
 Domain of $f \circ g$: $[-1, 1]$.
-
----
 
 ## Inverse Functions
 
@@ -192,8 +188,6 @@ $$
 
 and similarly $t(h(x)) = x$. So $t = h^{-1}$. 
 
----
-
 ## Toolkit: When to Reach for Which Technique
 
 | Situation | What to do |
@@ -207,8 +201,6 @@ and similarly $t(h(x)) = x$. So $t = h^{-1}$.
 | Find $f^{-1}(x)$ in general | Solve $f(y) = x$ for $y$ |
 | Identify transformations | Compare to parent form; shifts, flips, stretches |
 | $f^n(x)$ for large $n$ | Compute first few, find period $k$, reduce $n \bmod k$ |
-
----
 
 ## Remarks
 

--- a/content/2_Intermediate/Functional_Equations_p1.mdx
+++ b/content/2_Intermediate/Functional_Equations_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: functional-equations-p1
-title: Functional Equations (Part 1)
+title: Functional Equations I
 author: USAMO Guide Team
 description: Learn the main strategies for solving intermediate functional equations, including substitution, injectivity, surjectivity, fixed points, and guessing forms.
 prerequisites: []

--- a/content/2_Intermediate/Functional_Equations_p2.mdx
+++ b/content/2_Intermediate/Functional_Equations_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: functional-equations-p2
-title: Functional Equations (Part 2)
+title: Functional Equations II
 author: USAMO Guide Team
 description: Learn the main strategies for solving intermediate functional equations, including substitution, injectivity, surjectivity, fixed points, and guessing forms.
 prerequisites: []

--- a/content/2_Intermediate/Inequalitites_Foundations.mdx
+++ b/content/2_Intermediate/Inequalitites_Foundations.mdx
@@ -126,8 +126,6 @@ When you face an inequality problem, run through this checklist:
 4. **Is it a linear expression bounded by an interval?** $\implies$ Just test the endpoints.
 5. **Always Check the Equality Condition:** If you find a minimum bound of 12, can the variables actually equal the numbers required to hit 12? If not, your bound is unreachable.
 
----
-
 ## Worked Examples
 
 ### Example 1: Bounding Products with Mixed Signs

--- a/content/2_Intermediate/Regular_Polygons.mdx
+++ b/content/2_Intermediate/Regular_Polygons.mdx
@@ -14,8 +14,6 @@ These two conditions are equivalent for convex polygons, and there are many stra
 The key is having the right formulas memorized and knowing when to exploit
 symmetry rather than brute-forcing coordinates.
 
----
-
 ## Angles
 
 ### Interior Angle
@@ -54,8 +52,6 @@ are equal and they sum to $360°$, each must be $360°/n$.)
 | 12 | Dodecagon | 150° | 30° |
 
 
----
-
 ## Side Length, Circumradius, and Inradius
 
 We have a regular $n$-gon with center $O$, side length $s$, and circumradius $R$
@@ -82,8 +78,6 @@ r = R\cos\!\left(\frac{\pi}{n}\right), \qquad R^2 = r^2 + \left(\frac{s}{2}\righ
 $$
 
 The second identity follows from the Pythagorean theorem applied to the right triangle formed by $R$, $r$, and $s/2$.
-
----
 
 ## Area of Polygons
 
@@ -125,8 +119,6 @@ $$
 
 For hexagons, $R = s$, where the circumradius equals the side length.
 
----
-
 ## Diagonals
 
 Another important concept when talking about regular $n$-gon is that it has $\binom{n}{2} - n = \dfrac{n(n-3)}{2}$ diagonals.
@@ -140,8 +132,6 @@ $$
 
 We can prove this identity because the central angle subtended is $2\pi k/n$, and from the
 chord length formula, we get $d_k = 2R\sin(k\pi/n)$.
-
----
 
 ## Symmetry
 
@@ -162,8 +152,6 @@ A regular $n$-gon has:
 **Solution.** Exterior angle $= 180° - 150° = 30°$. Since exterior angles
 sum to $360°$: $n = 360°/30° = \mathbf{12}$ sides.
 
----
-
 ### Example 2: Finding Diagonals of a Hexagon 
 
 **Problem.** A regular hexagon has side length $2$. What is the area of the
@@ -179,8 +167,6 @@ $$
 A = \frac{(2\sqrt{3})^2 \sqrt{3}}{4} = \frac{12\sqrt{3}}{4} = \mathbf{3\sqrt{3}}.
 $$
 
----
-
 ### Example 3: Area via Apothem 
 
 **Problem.** A regular octagon is inscribed in a circle of radius $5$.
@@ -191,8 +177,6 @@ Find the area of the octagon.
 $$
 A = \frac{1}{2}(8)(25)\sin(45°) = 100 \cdot \frac{\sqrt{2}}{2} = \mathbf{50\sqrt{2}}.
 $$
-
----
 
 ### Example 4: Using Pentagons and its Golden Ratio 
 

--- a/content/2_Intermediate/Sequences_Series_p1.mdx
+++ b/content/2_Intermediate/Sequences_Series_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: sequences-series-intermediate-p1
-title: Sequences and Series
+title: Sequences and Series I
 author: Mehul Biala
 description: A comprehensive deep-dive into AMC 10/12 sequence strategies, including structure recognition, advanced telescoping, fixed-point recurrences, polynomial summation, and Fibonacci identities.
 prerequisites: ["algebraic-manipulations", "polynomials-fundamentals"]
@@ -70,7 +70,6 @@ a_{n+1} - a_n = (n+1)^3 - n^3 = 3n^2 + 3n + 1
 $$
 Notice how the cubic sequence produced a quadratic difference sequence!
 
----
 ## 2. Sigma Manipulation & Power Sums
 You must be fluid in splitting sums apart using the linearity of summation. For example, $\sum_{k=1}^{n}(k^2 + 2k + 1)$ instantly becomes $\sum k^2 + 2\sum k + \sum 1$. 
 Memorize the foundational power sums:
@@ -84,8 +83,6 @@ $$
 \sum_{k=1}^{100} k(101-k)
 $$
 By recognizing that term $k=1$ equals term $k=100$, you can exploit the sequence's symmetry to halve the computation time or reduce it into paired blocks.
-
----
 
 ## 3. Geometric Series & Arithmetico-Geometric Series
 ### The Finite Geometric Series Derivation
@@ -116,8 +113,6 @@ $$
 ### The Arithmetico-Geometric Series (AGS)
 An AGS is formed by multiplying an Arithmetic Progression term-by-term with a Geometric Progression (e.g., $\sum \frac{n}{2^n}$). Never memorize the formula. Instead, apply the exact shift-and-subtract derivation used above for geometric series to eliminate the arithmetic component. 
 
----
-
 ## 4. Telescoping & Partial Fractions
 Because AMC writers love partial fractions, they deserve major attention. When you see a polynomial denominator like $\sum \frac{3}{(k+1)(k+4)}$, immediately split it: $\frac{1}{k+1} - \frac{1}{k+4}$. 
 ### How to Invent a Telescoping Series
@@ -136,8 +131,6 @@ Notice that $\frac{1}{1}$ and $\frac{1}{2}$ survive at the beginning, while $-\f
 ### Bounding and Estimation
 To estimate $\sum_{k=1}^{100} \frac{1}{k^2}$ without exact computation, bound it using a telescoping series you *can* compute: $\frac{1}{k^2} < \frac{1}{k(k-1)}$. Then telescope the larger bound to prove the original sum is strictly bounded.
 
----
-
 ## 5. Sequence Transformations
 When a recurrence looks terrifying, the trick is to transform the sequence by measuring the distance from its fixed point.
 Take $a_{n+1} = \frac{a_n + 2}{a_n + 5}$. 
@@ -145,8 +138,6 @@ Students often attack this directly and get bogged down in massive rational expr
 1. **Find the fixed point:** Set $L = \frac{L+2}{L+5} \implies L^2 + 5L = L + 2 \implies L^2 + 4L - 2 = 0$.
 2. **Measure distance from fixed point:** Let the roots be $\alpha$ and $\beta$. Transform the recurrence by evaluating $\frac{a_{n+1} - \alpha}{a_{n+1} - \beta}$. 
 3. This completely neutralizes the complex recurrence, turning it into a simple geometric progression. This is arguably more important than solving repeated characteristic roots on the AMC 12.
-
----
 
 ## 6. Limits, Fixed Points, and Equilibrium
 While AMC 10 focuses on calculating specific terms, AMC 12 is obsessed with the asymptotic behavior of recurrences. The unifying theme for all these problems is **$L = f(L)$**. If a sequence converges, its infinite tail is identical to the whole.
@@ -158,7 +149,6 @@ While AMC 10 focuses on calculating specific terms, AMC 12 is obsessed with the 
 * **Recursive Limits:** $a_{n+1} = \frac{a_n + 2}{3}$. 
   Assume convergence to $L$. Then $L = \frac{L+2}{3} \implies 3L = L + 2 \implies 2L = 2 \implies L = 1$.
 
----
 ## 7. Fibonacci & Special Sequences
 The AMC 12 loves the Fibonacci sequence ($F_n = F_{n-1} + F_{n-2}$, where $F_1=1, F_2=1$). Do not rely on computing terms manually; you must know the structural identities:
 
@@ -167,7 +157,6 @@ The AMC 12 loves the Fibonacci sequence ($F_n = F_{n-1} + F_{n-2}$, where $F_1=1
 * **Double Index Formula:** $F_{2n} = F_n L_n$ (where $L_n$ is the Lucas Number)
 * **Binet's Formula / Approximation:** $F_n = \frac{\phi^n - \psi^n}{\sqrt{5}}$. Because $\psi^n$ approaches zero rapidly, $F_n \approx \frac{\phi^n}{\sqrt{5}}$ (where $\phi = \frac{1+\sqrt{5}}{2}$).
 
----
 ## 8. Periodicity & Roots of Unity
 
 Many seemingly infinite AMC 12 problems are actually periodicity problems.

--- a/content/2_Intermediate/Sequences_Series_p2.mdx
+++ b/content/2_Intermediate/Sequences_Series_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: sequences-series-intermediate-p2
-title: Sequences and Series
+title: Sequences and Series II
 author: Mehul Biala
 description: A comprehensive deep-dive into AMC 10/12 sequence strategies, including structure recognition, advanced telescoping, fixed-point recurrences, polynomial summation, and Fibonacci identities.
 prerequisites: ["algebraic-manipulations", "polynomials-fundamentals"]
@@ -16,7 +16,6 @@ If this quadratic has distinct roots $r_1, r_2$, the formula is $x_n = C_1(r_1)^
 * **Repeated Roots:** If $(r-1)^2 = 0$, the roots repeat, and the solution takes the form $a_n = C_1 + C_2n$.
 * **Complex Roots:** Equations like $r^2 - 2r + 2 = 0$ yield $1 \pm i$. This indicates the sequence will oscillate.
 
----
 ## 10. AMC Tricks
 
 When you see these expressions on a contest, bypass standard algebra and use these direct rewrites:
@@ -30,8 +29,6 @@ When you see these expressions on a contest, bypass standard algebra and use the
 | $\frac{1}{k^2-1}$ | $\frac{1}{2}(\frac{1}{k-1} - \frac{1}{k+1})$ | Non-Adjacent Partial Fractions |
 | $a_{n+1} = pa_n + q$ | $b_{n+1} = p b_n$ | Shift by fixed point |
 | $a_{n+1} = f(a_n)$ | $L = f(L)$ | Find fixed point limit |
-
----
 
 ## Worked Examples
 

--- a/content/2_Intermediate/Shoelace_Theorem_p1.mdx
+++ b/content/2_Intermediate/Shoelace_Theorem_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: shoelace-theorem-p1
-title: Shoelace Theorem (Part 1)
+title: Shoelace Theorem I
 author: Pranav Ramesh
 description: Computing polygon areas from coordinates using the Shoelace (Surveyor's) Formula, with AMC/AIME-level applications.
 prerequisites: [coordinate-geometry-basics, line-equations]
@@ -12,8 +12,6 @@ difficulty: AMC 10/12
 The **Shoelace Theorem** (also called the **Surveyor's Formula** or **Gauss's Area Formula**) gives the exact area of any polygon whose vertices are known as coordinate pairs. Unlike decomposition into triangles or the use of bounding rectangles, the Shoelace Theorem works directly and mechanically — making it one of the most powerful tools in coordinate geometry competitions.
 
 A single formula handles triangles, quadrilaterals, pentagons, and any simple (non-self-intersecting) polygon, no matter how irregular.
-
----
 
 ## 1. Statement of the Theorem
 
@@ -47,8 +45,6 @@ $$
 
 Without the absolute value, the formula gives a **signed area**: positive if vertices are listed counterclockwise, negative if clockwise. The signed area is useful in advanced settings (e.g., computing winding numbers or oriented areas in vector geometry).
 
----
-
 ## 2. Why It's Called "Shoelace"
 
 List the coordinates in two columns, then repeat the first row at the bottom:
@@ -79,8 +75,6 @@ $$
 [ABC] = \frac{1}{2} \left| \det \begin{pmatrix} x_1 - x_3 & x_2 - x_3 \\ y_1 - y_3 & y_2 - y_3 \end{pmatrix} \right|
 $$
 
----
-
 ## 3. Special Cases
 
 ### Triangle
@@ -98,8 +92,6 @@ For a quadrilateral with perpendicular diagonals: $[\text{quad}] = \frac{1}{2}d_
 ### Collinearity Test
 
 If $[ABC] = 0$, the three points are **collinear**. 
-
----
 
 ## 4. Key Properties and Insights
 
@@ -123,8 +115,6 @@ For any triangulation of the polygon (dividing it into non-overlapping triangles
 
 Shoelace works for **any simple polygon** (no self-intersections), convex or not. Self-intersecting polygons require special care (the formula gives a signed sum that can cause cancellation.)
 
----
-
 ## 5. Connection to the Determinant
 
 The Shoelace formula is deeply connected to the **$2 \times 2$ determinant**:
@@ -136,8 +126,6 @@ $$
 Each term $x_i y_{i+1} - x_{i+1} y_i$ is the determinant of the $2\times 2$ matrix formed by the $i$-th and $(i+1)$-th vertices. Geometrically, this determinant equals the **signed area of the parallelogram** spanned by the two position vectors, so half of it is the area of the triangle formed with the origin.
 
 The full Shoelace sum is therefore the signed area of the polygon as seen from the origin, computed by summing up the signed areas of the "fan" of triangles from the origin to each edge.
-
----
 
 ## 6. Worked Examples
 
@@ -158,8 +146,6 @@ $$
 
 $\boxed{\dfrac{25}{2}}$
 
----
-
 ### Worked Example 2 — Quadrilateral
 
 Find the area of the quadrilateral with vertices $A(0,0)$, $B(4,0)$, $C(5,3)$, $D(1,4)$ in that order.
@@ -179,8 +165,6 @@ $$
 $$
 
 $\boxed{\dfrac{29}{2}}$
-
----
 
 ### Worked Example 3 — Medians and Centroid (AMC Style)
 
@@ -212,8 +196,6 @@ $$
 $\boxed{1}$
 
 > **Key Insight:** The centroid divides any triangle into 6 triangles of equal area. The triangle formed by two vertices and the centroid always has area $= \frac{1}{3}[ABC]$.
-
----
 
 ### Worked Example 4 — AMC 2004 #16 (Logarithmic Quadrilateral)
 
@@ -273,8 +255,6 @@ Since $91 = 7 \times 13$, the numerator $(n+1)(n+2)$ must contain a factor of $1
 The answer is $\boxed{12}$.
 
 > **Technique Spotlight:** This problem demonstrates that Shoelace can handle points on a curve — you just treat the coordinates algebraically and simplify using logarithm rules. The key was recognizing that all the messy $\ln$ terms collapse beautifully.
-
----
 
 # Part 2:
 Due to Size constraints, this module has been split in two. Check out Part 2 for the rest of the content. 

--- a/content/2_Intermediate/Shoelace_Theorem_p2.mdx
+++ b/content/2_Intermediate/Shoelace_Theorem_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: shoelace-theorem-p2
-title: Shoelace Theorem (Part 2)
+title: Shoelace Theorem II
 author: Pranav Ramesh
 description: Computing polygon areas from coordinates using the Shoelace (Surveyor's) Formula, with AMC/AIME-level applications.
 prerequisites: [coordinate-geometry-basics, line-equations]
@@ -27,8 +27,6 @@ $$
 [P] = \frac{1}{2}|(0+15+16+4+0)-(0+0+6+0+0)| = \frac{1}{2}|35-6| = \boxed{\dfrac{29}{2}}
 $$
 
----
-
 ### Worked Example 6 — Area Expressed Algebraically
 
 A triangle has vertices $(0,0)$, $(a,b)$, $(c,d)$. Show that its area is $\frac{1}{2}|ad-bc|$.
@@ -46,8 +44,6 @@ $$
 $$
 
 This is exactly $\frac{1}{2}|\det\begin{pmatrix}a&b\\c&d\end{pmatrix}|$, confirming the determinant interpretation. 
-
----
 
 ## 7. Pick's Theorem (Companion Result)
 
@@ -71,8 +67,6 @@ $$
 B = \sum_{\text{edges}} \gcd(|\Delta x|, |\Delta y|)
 $$
 
----
-
 ## 8. Common Competition Techniques
 
 ### 8.1 Subtract Areas
@@ -95,8 +89,6 @@ When vertices lie on a curve (like $y=\ln x$ or $y=x^2$), apply Shoelace with co
 
 If triangle $ABC$ has area $S$ and point $P = \alpha A + \beta B + \gamma C$ (with $\alpha+\beta+\gamma=1$) is inside it, then $[PBC] = \alpha S$, $[APC] = \beta S$, $[ABP] = \gamma S$. These are the **barycentric coordinates** of $P$ — they equal the ratio of the sub-triangle areas to the whole.
 
----
-
 ## 9. Strategy Checklist
 
 **Before applying Shoelace:**
@@ -114,8 +106,6 @@ If triangle $ABC$ has area $S$ and point $P = \alpha A + \beta B + \gamma C$ (wi
 - Cross-check with a decomposition into triangles when possible.
 - For lattice polygons, verify with Pick's theorem if $I$ and $B$ are easy to count.
 
----
-
 ## 10. Common Pitfalls
 
 - **Wrong vertex order.** Listing vertices out of rotational order (e.g., skipping across the polygon) is the most common error. Always draw the polygon first.
@@ -124,8 +114,6 @@ If triangle $ABC$ has area $S$ and point $P = \alpha A + \beta B + \gamma C$ (wi
 - **Self-intersecting polygons.** Shoelace gives a net signed area. For a self-intersecting polygon (like a star polygon), the formula does not give the total enclosed area.
 - **Confusing CW vs. CCW.** Both work — just take the absolute value. Only matters if you need the signed area.
 - **Pick's theorem on non-lattice polygons.** Pick's theorem requires all vertices to be lattice points. Shoelace has no such restriction.
-
----
 
 ## Practice Problems
 
@@ -160,8 +148,6 @@ If triangle $ABC$ has area $S$ and point $P = \alpha A + \beta B + \gamma C$ (wi
 12. **(AIME Style)** Let $P$ be the polygon with vertices at all lattice points $(x,y)$ with $|x|+|y| \leq 3$. Compute the area of $P$ using the Shoelace theorem applied to its boundary vertices listed in order.
 
 13. **(Area Ratio)** In $\triangle ABC$ with $A(0,0)$, $B(4,0)$, $C(1,3)$, cevian $AD$ is drawn where $D$ divides $BC$ in ratio $BD:DC = 2:1$. Find $[ABD]:[ADC]:[ABC]$ using Shoelace, and verify Ceva's theorem.
-
----
 
 ## Answer Key (Selected)
 

--- a/content/2_Intermediate/Symmetric_Polynomials.mdx
+++ b/content/2_Intermediate/Symmetric_Polynomials.mdx
@@ -10,8 +10,6 @@ prerequisites: ["vieta-formulas", "newton-sums"]
 
 A polynomial in several variables is **symmetric** if it is unchanged under any permutation of its variables. For example, $r^2 + s^2$ is symmetric (swapping gives $s^2 + r^2$, which is identical), but $r + 2s$ is not (swapping gives $s + 2r \neq r + 2s$). Symmetric polynomials arise naturally from polynomial roots: every expression Vieta's formulas produce is symmetric in the roots by construction. The basic idea is that since we are able to switch up various variables without changing it, we can use various constructions to our advantage
 
----
-
 ## Elementary Symmetric Polynomials
 
 The **elementary symmetric polynomials** $S_k$ in variables $x_1, \ldots, x_n$ are defined as the sum of all distinct products of exactly $k$ variables:
@@ -34,13 +32,9 @@ $$
 \prod_{i=1}^n (1 + x_i t) = 1 + S_1 t + S_2 t^2 + \cdots + S_n t^n
 $$
 
----
-
 ## Fundamental Theorem of Symmetric Polynomials
 
 **Theorem.** Every symmetric polynomial with integer (or rational, or real) coefficients can be written *uniquely* as a polynomial in $S_1, S_2, \ldots, S_n$.
-
----
 
 ## Key Techniques
 
@@ -74,8 +68,6 @@ where $T_k$ satisfies the same recurrence $T_k = y \cdot T_{k-1} - T_{k-2}$. Thi
 
 To evaluate $(r_1 + c)(r_2 + c) \cdots (r_n + c)$ where $r_i$ are roots of $f(x)$: substitute $x = y - c$ to get a new polynomial $g(y) = f(y-c)$ whose roots are $r_i + c$. The product equals $\pm g(0)/a_n$ by Vieta's.
 
----
-
 ## Worked Examples
 
 **Example 1.** Express $x^2 + y^2 + z^2$ in terms of $S_1, S_2, S_3$.
@@ -83,8 +75,6 @@ To evaluate $(r_1 + c)(r_2 + c) \cdots (r_n + c)$ where $r_i$ are roots of $f(x)
 Expand $S_1^2 = (x+y+z)^2 = x^2+y^2+z^2 + 2(xy+yz+zx) = x^2+y^2+z^2 + 2S_2$.
 
 Rearranging: $\boxed{x^2+y^2+z^2 = S_1^2 - 2S_2}$.
-
----
 
 **Example 2.** Given $a+b = 1$ and $a^2+b^2 = 2$, find $a^3+b^3$.
 
@@ -100,8 +90,6 @@ $$
 a^3+b^3 = s(s^2-3p) = 1\!\cdot\!\left(1 - 3\!\cdot\!\left(-\tfrac{1}{2}\right)\right) = 1 \cdot \tfrac{5}{2} = \boxed{\tfrac{5}{2}}
 $$
 
----
-
 **Example 3.** Let $a, b, c$ be roots of $f(x) = x^3 + 8x + 5 = 0$. Find $(1+a)(1+b)(1+c)$.
 
 Do not use $S_k$ directly — instead construct a polynomial with roots $1+a, 1+b, 1+c$. Substitute $x = y - 1$:
@@ -111,8 +99,6 @@ g(y) = (y-1)^3 + 8(y-1) + 5 = y^3 - 3y^2 + 3y - 1 + 8y - 8 + 5 = y^3 - 3y^2 + 11
 $$
 
 By Vieta's for $g$, the product of its roots is $-(-4)/1 = \boxed{4}$.
-
----
 
 **Example 4.** Solve $x^4 + x^3 + x^2 + x + 1 = 0$.
 
@@ -130,13 +116,9 @@ $$
 
 For each value of $u$, solve $x + x^{-1} = u$, i.e., $x^2 - ux + 1 = 0$, giving the four roots of the original.
 
----
-
 **Example 5 (Discriminant).** Determine whether a polynomial has a repeated root using only its coefficients.
 
 A polynomial $f(x)$ with roots $x_1, \ldots, x_n$ has a repeated root iff $\Delta = \prod_{i < j}(x_i - x_j)^2 = 0$. Since $\Delta$ is symmetric in the roots, the Fundamental Theorem guarantees it is a polynomial in $S_1, \ldots, S_n$. By Vieta's, each $S_k$ is a coefficient of $f$ up to sign. Therefore $\Delta$ — the **discriminant** — is computable purely from the coefficients of $f$ using arithmetic operations.
-
----
 
 ## Common Pitfalls
 
@@ -149,8 +131,6 @@ A polynomial $f(x)$ with roots $x_1, \ldots, x_n$ has a repeated root iff $\Delt
 **Palindromic substitution cross-term.** When substituting $y = x + x^{-1}$, do not write $x^2 + x^{-2} = y^2$. The correct identity is $x^2 + x^{-2} = y^2 - 2$ (the cross term $2 \cdot x \cdot x^{-1} = 2$ must be subtracted).
 
 **Root multiplicity.** If every root of $g(x)$ is also a root of $f(x)$, this does not mean $g \mid f$. You must verify that the multiplicity of each shared root in $g$ does not exceed its multiplicity in $f$.
-
----
 
 ## Practice Problems
 

--- a/content/2_Intermediate/Trig_Angle_Addition_p1.mdx
+++ b/content/2_Intermediate/Trig_Angle_Addition_p1.mdx
@@ -1,6 +1,6 @@
 ---
 id: trigonometric-identities-and-series-p1
-title: Trigonometric Identities and Series (Part 1)
+title: Trigonometric Identities and Series I
 author: Neronvain
 description: Learn how product to sum identities, double angle formulas, triple angle formulas, and trigonometric series simplify olympiad style trigonometry problems.
 prerequisites: []

--- a/content/2_Intermediate/Trig_Angle_Addition_p2.mdx
+++ b/content/2_Intermediate/Trig_Angle_Addition_p2.mdx
@@ -1,6 +1,6 @@
 ---
 id: trigonometric-identities-and-series-p2
-title: Trigonometric Identities and Series (Part 2)
+title: Trigonometric Identities and Series II
 author: Neronvain
 description: Learn how product to sum identities, double angle formulas, triple angle formulas, and trigonometric series simplify olympiad style trigonometry problems.
 prerequisites: []

--- a/content/2_Intermediate/Trig_Unit_Circle.mdx
+++ b/content/2_Intermediate/Trig_Unit_Circle.mdx
@@ -243,8 +243,6 @@ $$
 
 Every formula below follows from the same rotation argument.
 
----
-
 ### Shifts by $90°$
 
 | Function | $90° - \theta$ | $90° + \theta$ |
@@ -257,8 +255,6 @@ Every formula below follows from the same rotation argument.
 | $\csc$ | $\sec\theta$ | $\sec\theta$ |
 
 *Function swaps* (sin↔cos, tan↔cot, sec↔csc). Sign from ASTC: $90° - \theta$ stays in Q I (all positive); $90° + \theta$ lands in Q II (only sine and cosecant positive).
-
----
 
 ### Shifts by $180°$
 
@@ -273,8 +269,6 @@ Every formula below follows from the same rotation argument.
 
 *Function stays the same*. $180° - \theta$ is in Q II (sin and csc positive, rest negative); $180° + \theta$ is in Q III (tan and cot positive, rest negative).
 
----
-
 ### Shifts by $270°$
 
 | Function | $270° - \theta$ | $270° + \theta$ |
@@ -288,8 +282,6 @@ Every formula below follows from the same rotation argument.
 
 *Function swaps* again (odd multiple of $90°$). $270° - \theta$ is in Q III (tan and cot positive); $270° + \theta$ is in Q IV (cos and sec positive).
 
----
-
 ### Shifts by $360°$ (and negative angles)
 
 | Function | $-\theta$ | $360° - \theta$ | $360° + \theta$ |
@@ -302,8 +294,6 @@ Every formula below follows from the same rotation argument.
 | $\csc$ | $-\csc\theta$ | $-\csc\theta$ | $\csc\theta$ |
 
 *Function stays the same* (even multiple of $90°$). $360° + \theta$ is just periodicity, a full revolution returns to the same point. $-\theta$ and $360° - \theta$ both reflect across the $x$-axis: the $y$-coordinate negates while $x$ stays fixed, which is exactly why sine is an **odd** function ($\sin(-\theta) = -\sin\theta$) and cosine is an **even** function ($\cos(-\theta) = \cos\theta$).
-
----
 
 ### Quick-fire examples
 

--- a/content/2_Intermediate/Vieta_Jumping.mdx
+++ b/content/2_Intermediate/Vieta_Jumping.mdx
@@ -10,8 +10,6 @@ prerequisites: ["vieta-formulas", "number-theory-intermediate","Fermat's Infinit
 
 Vieta Jumping (also called root flipping) is an advanced technique where we perform fermats's infinite descent with the usual goal of showing there exists finite solutions to a diophantine equations however with a twist where the descent is performed on the roots of a quadriatic expression where the roots are usually the solutions to the equation. The roots are found by vieta and hence the name 'Vieta Jumping'.
 
----
-
 ## Key Idea
 First we have a diophantine equation which is **symmetric** and we want to perform the vita jump on it. Let us represent this by $f(a,b)=k$ with degree 2. Degree 1 is left out as that will result a linear diophantine equation which can be solved by standard methods. Now we can form a quadriatic equation with either $a$ or $b$ as the subject and $k$ as the value of the diophantine equation.
 
@@ -33,8 +31,6 @@ $$
 (The most popular is contradiction, which is outlined below)
 
 
----
-
 ## Steps to Reproduce
 
 Here is the standard structure of a Vieta Jumping argument (This is only for reference and not for forced memorisation):
@@ -46,8 +42,6 @@ Here is the standard structure of a Vieta Jumping argument (This is only for ref
 5. **Show $x > 0$.** Use the product formula $xa = (\text{constant})$. If $k$ is not a perfect square or if the constant is positive, show $x \neq 0$; rule out $x < 0$ separately.
 6. **Show $x < a$.** Use the assumption $a \geq b$ and the product formula: $x = \frac{b^2 - k}{a} \leq \frac{a^2 - k}{a} < a$.
 7. **Conclude.** The pair $(x, b)$ satisfies the same relation with $x + b < a + b$, contradicting minimality. Hence no such pair exists (or $k$ must equal the forced value).
-
----
 
 ## Worked Examples
 
@@ -84,8 +78,6 @@ We need to show this is less than $a$. Note $k \geq 1$, so $b^2 - k \leq b^2 - 1
 
 But then $(x, b)$ is a valid pair achieving the same $k$, with $x < a$ — contradicting the minimality of $a$. Therefore, no non-perfect-square value of $k$ is achievable, and $k$ must be a perfect square. $\blacksquare$
 
----
-
 **Example 2.** Let $a, b$ be positive integers with $ab \mid a^2 + b^2 + 1$. Show that $\dfrac{a^2 + b^2 + 1}{ab} = 3$.
 
 **Proof.** Let $k = \frac{a^2+b^2+1}{ab}$. First handle the diagonal: if $a = b$, then $a^2 \mid 2a^2 + 1$, so $a^2 \mid 1$, forcing $a = b = 1$ and $k = 3$. Now assume $a > b \geq 1$ and pick the minimal-sum pair.
@@ -111,8 +103,6 @@ $$
 
 So $(x, b)$ is a valid pair with $x < a$, contradicting minimality — unless no such pair with $a > b$ exists. The descent terminates when $a = b$, which forces $k = 3$ as shown above. Therefore $k = 3$ for all valid pairs. $\blacksquare$
 
----
-
 ## Common Pitfalls
 
 **Forgetting to prove $x > 0$.** The extremal argument only produces a contradiction if the new solution is a valid pair of positive integers. Always prove $x > 0$, or handle $x = 0$ as an explicit base case.
@@ -122,8 +112,6 @@ So $(x, b)$ is a valid pair with $x < a$, contradicting minimality — unless no
 **Not verifying the new pair satisfies the relation.** Check that $(x, b)$ (not just $(a, b)$) satisfies the original equation before claiming it's a valid smaller solution.
 
 **Negative variables.** The extremal principle requires $a + b$ to be bounded below. If the problem allows negative integers, the descent has no floor. Establish that any solution can be transformed to a positive one before applying the method.
-
----
 
 ## Practice Problems
 

--- a/content/3_Advanced/Counting_Advanced.mdx
+++ b/content/3_Advanced/Counting_Advanced.mdx
@@ -89,15 +89,11 @@ states. Each state contributes a recurrence.
 If $f(n)=c_1 f(n-1)+c_2 f(n-2)$, solve $r^2-c_1 r-c_2=0$. Then
 $f(n)=A r_1^n + B r_2^n$ with constants from base cases.
 
----
-
 ### Example 1: Explicit Recurrence
 
 Suppose $f(n)=2f(n-1)-2^n$ with $f(0)=5$.
 The homogeneous solution is $C\cdot 2^n$. A particular solution is
 $-n\cdot 2^n$. So $f(n)=(5-n)2^n$.
-
----
 
 ### Example 2: Catalan Bijections
 
@@ -322,8 +318,6 @@ C_6=\frac{1}{7}\binom{12}{6}
 =\frac{924}{7}
 =\mathbf{132}.
 $$
-
----
 
 ## Practice Problems
 

--- a/content/3_Advanced/Gaussian_Integrals.mdx
+++ b/content/3_Advanced/Gaussian_Integrals.mdx
@@ -106,8 +106,6 @@ $$
 I = \sqrt{\pi} \tag{2.8}
 $$
 
----
-
 **Example 1:** Show that the general Gaussian integral is
 
 $$
@@ -127,8 +125,6 @@ I^2 = A^2 \int_0^{\infty} \frac{2\pi r}{2ar} e^{-u}\,du = A^2 \int_0^{\infty} \f
 $$
 
 which means $I = A\sqrt{\pi/a}$.
-
----
 
 **Example 2:** In thermodynamics, the Maxwell–Boltzmann velocity distribution describes the distribution of velocities of molecules in an ideal gas. The PDF for the $x$-component of velocity $v_x$ is:
 
@@ -186,8 +182,6 @@ $$
 
 Note that the lower limit is $0$. Since $x\exp(-x^2)$ is an odd function, the integral from $(-\infty, \infty)$ is trivially zero and not particularly interesting.
 
----
-
 **Example 3:** Show that $I_1 = 1/2$ in Equation (4.1).
 
 **Solution 3:** $I_1$ is easily evaluated using $u$-substitution:
@@ -197,8 +191,6 @@ I_1 = \int_0^{\infty} x e^{-x^2}\,dx = \int_0^{\infty} e^{-x^2} \frac{1}{2}\,dx^
 $$
 
 The usual $u$-substitution has been written as $x\,dx = \frac{1}{2}\,dx^2$, which is just $u = x^2$ in convenient notation.
-
----
 
 Now consider the integral $I_2$:
 
@@ -219,8 +211,6 @@ I_2 = \frac{\sqrt{\pi}}{2} \tag{4.6}
 $$
 
 The process of $u$-substitution with integration by parts can be repeated to find expectation values of successively higher powers of $x^n$ in a Gaussian distribution.
-
----
 
 **Example 4:** Evaluate the integral
 

--- a/content/3_Advanced/Integration_by_Parts.mdx
+++ b/content/3_Advanced/Integration_by_Parts.mdx
@@ -34,8 +34,6 @@ $$
 
 This is the **Integration by Parts** formula. It comes to a rescue when the product of two different functions needs to be integrated and calculating $\displaystyle\int v\,du$ is easier than calculating $\displaystyle\int u\,dv$.
 
----
-
 **Example 1:** Solve $\displaystyle\int x\ln(x)\,dx$
 
 **Solution:**
@@ -50,8 +48,6 @@ $$
 \int x\ln(x)\,dx = \frac{x^2}{2}\ln(x) - \int \frac{x^2}{2} \cdot \frac{1}{x}\,dx = \frac{x^2}{2}\ln(x) - \int \frac{x}{2}\,dx = \frac{x^2}{2}\!\left(\ln(x) - \frac{1}{2}\right)
 $$
 
----
-
 The tricky part in applying integration by parts is how to select $u$ and $dv$ so that finding the value will be easy. When $u\,dv$ is complex, this is especially tricky, as finding the proper $u$ and $dv$ by trial and error takes a lot of time. With practice, one can find proper $u$ and $dv$ easily and faster.
 
 Before applying the rule, keep in mind that:
@@ -61,8 +57,6 @@ Before applying the rule, keep in mind that:
 If it is known that one of these will fail, we can select other values and avoid wasting time. It is also possible that the integral may be solved more easily by $u$-substitution — testing other integration methods before resorting to integration by parts is usually advised.
 
 Sometimes, one can apply integration by parts **several times in succession**:
-
----
 
 **Example 2:** Find $\displaystyle\int x^n e^x\,dx$
 
@@ -85,8 +79,6 @@ $$
 $$
 
 Note that we continue this until the powers of $x$ and $e$ go to zero.
-
----
 
 **Example 3 — Reduction Formula:** Another cool example is the reduction of $A_n = \displaystyle\int \sin^n x\,dx$:
 

--- a/content/3_Advanced/Intro_to_Vectors.mdx
+++ b/content/3_Advanced/Intro_to_Vectors.mdx
@@ -24,8 +24,6 @@ In mathematics, vectors are indispensable tools in geometry, and are used extens
 - In $\mathbb{R}^2$, every vector can be written as a linear combination of the standard basis vectors $\mathbf{i}$ and $\mathbf{j}$.
 - A **unit vector** has magnitude equal to 1; given any nonzero vector $\mathbf{v}$, its normalization is $\mathbf{u} = \frac{1}{|\mathbf{v}|}\mathbf{v}$.
 
----
-
 ## 1. Vectors
 
 ### Vectors as Arrows
@@ -507,8 +505,6 @@ $$
 \mathbf{v} = \frac{1}{3}\mathbf{u}.
 $$
 
----
-
 ## 2. Vector Components
 
 So far all of our discussion of vectors has been from the viewpoint of Euclidean geometry. However, in modern mathematics it is much more common to take an analytic approach to geometry, identifying each point in the plane with an ordered pair $(x, y)$ of real coordinates. The resulting plane is sometimes called the $xy$-plane, but in linear algebra and advanced mathematics it is more often referred to as $\mathbb{R}^2$.
@@ -841,8 +837,6 @@ $$
 $$
 
 The second equation tells us that $y = 6 - 3x$. Plugging this into the first equation and solving for $x$ yields $x = 1$, and it follows that $y = 3$.
-
----
 
 ## 3. Vector Geometry
 
@@ -1382,8 +1376,6 @@ Then
 $$
 \mathbf{p} = (2, 3) + \mathbf{v} = (2, 3) + \frac{2}{\sqrt{10}}\begin{bmatrix} 3 \\ 1 \end{bmatrix} = \left(2 + \frac{6}{\sqrt{10}},\ 3 + \frac{2}{\sqrt{10}}\right).
 $$
-
----
 
 ## Practice Problems
 

--- a/content/4_USAMO/Proof_Writing_Basics.mdx
+++ b/content/4_USAMO/Proof_Writing_Basics.mdx
@@ -25,8 +25,6 @@ The main idea of proof writing is that everyone who reads the proof should be ab
 * Write in complete sentences and justify each step.
 * Identify and highlight the key invariant, idea, or construction early.
 
----
-
 ## Core Concepts
 
 ### Induction
@@ -97,8 +95,6 @@ This completes the inductive step.
 
 Therefore, the statement holds for all $n \ge 1$. $\square$
 
----
-
 ### Logical Chain
 
 Ensure your argument follows a clear logical progression:
@@ -135,8 +131,6 @@ Holds for all $a,b,c \in \mathbb{R}$
 
 **Note:** This example is of a cirular proof and the proof is wrong
 
----
-
 ### Structure
 
 Good structure is essential for clarity:
@@ -146,8 +140,6 @@ Good structure is essential for clarity:
 * Use a **Claim–Proof** format when appropriate.
 * Center important computations and separate them from text.
 * Guide the reader through your reasoning.
-
----
 
 ### Completeness Checklist
 
@@ -161,8 +153,6 @@ Many otherwise strong solutions lose points due to missing cases. Always verify:
 * Did I address edge cases (e.g., parallel lines in geometry)?
 * Did I explicitly justify equalities and constructions?
 
----
-
 ## Common Pitfalls
 
 * Failing to prove all required cases
@@ -170,7 +160,6 @@ Many otherwise strong solutions lose points due to missing cases. Always verify:
 * Poor structure or unclear organization
 * Usage of circular reasoning
 
----
 ## mathematical argument 
 In this section we talk about mathematical proofs; 
 you can't get a $7$ if you're mathematically wrong. 


### PR DESCRIPTION
…rules

- Rename "(Part 1)/(Part 2)" and "Part 1/2" module titles to "I"/"II" across 16 modules (Integer Operations, Chart & Graph Interpretation, Proportional Reasoning, Binomial Theorem, Function Basics, Functional Equations, Shoelace Theorem, Trig Identities & Series). Left "Integration by Parts" untouched (real title, not a split).
- Title the two Sequences and Series modules "I" and "II" (were both identically titled "Sequences and Series").
- Remove 205 horizontal-rule ("---") section dividers from module bodies across 35 files; these read as AI-generated and are visually noisy. Frontmatter delimiters and rules inside code fences are preserved.
- Fix pre-existing build break: 3 problems in Linear_Diophantine_Equations.problems.json shared a uniqueId with entries in other modules but used a different AoPS URL format, failing the createPages consistency check. Normalized their URLs to match the canonical existing entries.

_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have followed the content guidelines in docs/Math_Topic_Template.md.
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

- [x] I am 18 years or older, **OR** if I am under 18, my parent has read and agreed to the Parental Acknowledgment (link).
- [x] I am a volunteer. I expect no payment or ownership.
- [x] I agree to follow the Code of Conduct.