### PR TITLE
Correct condition for (N+1)/2 median term formula

### DIFF
--- a/content/1_Foundations/Mean_Median_Mode_Harmonic.mdx
+++ b/content/1_Foundations/Mean_Median_Mode_Harmonic.mdx
@@ -67,7 +67,7 @@ $$
 $$
 2. Identify the middle value (5 scores before, 5 scores after): **56**
 
-Note: the term can be found easily to be the $\frac{N + 1}{2}$'th term  for a list of N terms, where N is even.
+Note: the term can be found easily to be the $\frac{N + 1}{2}$'th term  for a list of N terms, where N is odd.
 
 #### Calculating with an Even Number of Scores
 

--- a/content/1_Foundations/Mean_Median_Mode_Harmonic.mdx
+++ b/content/1_Foundations/Mean_Median_Mode_Harmonic.mdx
@@ -61,11 +61,11 @@ $$
 65, 55, 89, 56, 35, 14, 56, 55, 87, 45, 92
 $$
 
-1. Arrange in order of magnitude: 
+1\. Arrange in order of magnitude: 
 $$ 
 14, 35, 45, 55, 55, 56, 56, 65, 87, 89, 92
 $$
-2. Identify the middle value (5 scores before, 5 scores after): **56**
+2\. Identify the middle value (5 scores before, 5 scores after): **56**
 
 Note: the term can be found easily to be the $\frac{N + 1}{2}$'th term  for a list of N terms, where N is odd.
 
@@ -76,11 +76,11 @@ $$
 65, 55, 89, 56, 35, 14, 56, 55, 87, 45
 $$
 
-1. Arrange in order of magnitude: 
+1\. Arrange in order of magnitude: 
 $$
 14, 35, 45, 55, 55, 56, 56, 65, 87, 89
 $$
-2. Take the average of the 5th and 6th scores:
+2\. Take the average of the 5th and 6th scores:
 
 $$
 \text{Median} = \frac{55 + 56}{2} = 55.5


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [ X] I have tested my code.
- [X ] I have followed the content guidelines in docs/Math_Topic_Template.md.
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [ ] I have linked this PR to any issues that it closes.

- [X ] I am 18 years or older, **OR** if I am under 18, my parent has read and agreed to the Parental Acknowledgment (link).
- [ X] I am a volunteer. I expect no payment or ownership.
- [X ] I agree to follow the Code of Conduct.

### Description
Fixed a conceptual typo in the Median module under the "Intro to statistics" section. Changed "where N is even" to "where N is odd" since the formula (N+1)/2 specifically applies to an odd number of terms. So, on the site it said even when the length of the set of numbers is odd.
<img width="979" height="397" alt="image" src="https://github.com/user-attachments/assets/6448b9db-5bd7-4151-b406-428dbc04a869" />
